### PR TITLE
Add changes suggested by Claude Code

### DIFF
--- a/TOPagingView/TOPagingView.h
+++ b/TOPagingView/TOPagingView.h
@@ -1,7 +1,7 @@
 //
 //  TOPagingView.h
 //
-//  Copyright 2018-2023 Timothy Oliver. All rights reserved.
+//  Copyright 2018-2026 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOPagingView/TOPagingView.h
+++ b/TOPagingView/TOPagingView.h
@@ -144,8 +144,11 @@ NS_SWIFT_NAME(PagingView)
 @interface TOPagingView : UIView
 
 /// The internal scroll view wrapped by this view that controls the scrolling content.
-/// The delegate is available for external objects to use.
 @property (nonatomic, strong, readonly) UIScrollView *scrollView;
+
+/// The delegate for the internal scroll view. Use this property instead of setting
+/// scrollView.delegate directly, as the paging view uses the delegate internally.
+@property (nonatomic, weak, nullable) id<UIScrollViewDelegate> scrollViewDelegate;
 
 /// The data source object that is in charge with configuring and providing views to this view.
 @property (nonatomic, weak, nullable) id <TOPagingViewDataSource> dataSource;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -21,6 +21,7 @@
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "TOPagingView.h"
+#import <objc/runtime.h>
 
 /// Mark methods as being statically called to increase performance
 #define TOPAGINGVIEW_OBJC_DIRECT __attribute__((objc_direct))
@@ -109,7 +110,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 @property (nonatomic, assign) TOPagingViewDelegateFlags delegateFlags;
 
 /// Struct to cache the protocol state of each type of page view class used in this session.
-@property (nonatomic, strong) NSMutableDictionary<NSString *, TOPageViewProtocolCache *> *pageViewProtocolFlags;
+/// Uses NSMapTable with pointer keys to avoid NSStringFromClass allocations on lookup.
+@property (nonatomic, strong) NSMapTable<Class, TOPageViewProtocolCache *> *pageViewProtocolFlags;
 
 /// Disable automatic layout when manually laying out content.
 @property (nonatomic, assign) BOOL disableLayout;
@@ -162,7 +164,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     // Set default values
     _pageSpacing = 40.0f;
     _queuedPages = [NSMutableDictionary dictionary];
-    _pageViewProtocolFlags = [NSMutableDictionary dictionary];
+    _pageViewProtocolFlags = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsOpaquePersonality
+                                                   valueOptions:NSPointerFunctionsStrongMemory];
     memset(&_delegateFlags, 0, sizeof(TOPagingViewDelegateFlags));
 
     // Configure the main properties of this view
@@ -417,8 +420,8 @@ static inline void TOPagingViewSetPageDirectionForPageView(TOPagingView *view, T
 
 static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageViewClass(TOPagingView *view, Class class)
 {
-    // Skip if we already captured the protocols from this class
-    TOPageViewProtocolCache *cache = view->_pageViewProtocolFlags[NSStringFromClass(class)];
+    // Skip if we already captured the protocols from this class (pointer-based lookup, no allocation)
+    TOPageViewProtocolCache *cache = [view->_pageViewProtocolFlags objectForKey:class];
     if (cache != nil) { return cache.flags; }
 
     // Create a new instance of the struct and prepare its memory
@@ -432,10 +435,10 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     flags.protocolIsInitialPage = [class instancesRespondToSelector:@selector(isInitialPage)];
     flags.protocolSetPageDirection = [class instancesRespondToSelector:@selector(setPageDirection:)];
 
-    // Store in the dictionary
+    // Store in the map table (pointer-based key, no allocation)
     cache = [TOPageViewProtocolCache new];
     cache.flags = flags;
-    view->_pageViewProtocolFlags[NSStringFromClass(class)] = cache;
+    [view->_pageViewProtocolFlags setObject:cache forKey:class];
 
     // Return the flags
     return flags;
@@ -460,9 +463,9 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     [_queuedPages removeAllObjects];
 
     // Reset the content size of the scroll view content
-    TOPagingViewPerformBlockWithoutLayout(self, ^{
-        self->_scrollView.contentSize = CGSizeZero;
-    });
+    _disableLayout = YES;
+    _scrollView.contentSize = CGSizeZero;
+    _disableLayout = NO;
 
     // Perform a fresh layout
     [self _layoutPages];
@@ -673,13 +676,6 @@ static inline void TOPagingViewPerformInitialLayout(TOPagingView *view)
     if (view->_delegateFlags.delegateDidTurnToPage) {
         [view->_delegate pagingView:view didTurnToPageOfType:TOPagingViewPageTypeCurrent];
     }
-}
-
-static inline void TOPagingViewPerformBlockWithoutLayout(TOPagingView *view, void (^block)(void))
-{
-    view->_disableLayout = YES;
-    if (block) { block(); }
-    view->_disableLayout = NO;
 }
 
 static inline void TOPagingViewHandleDynamicPageDirectionLayout(TOPagingView *view)
@@ -1105,8 +1101,8 @@ static void TOPagingViewReclaimPageView(TOPagingView *view, UIView *pageView)
 {
     if (pageView == nil) { return; }
 
-    // Skip internal UIScrollView views
-    if ([NSStringFromClass([pageView class]) characterAtIndex:0] == '_') {
+    // Skip internal UIScrollView views (use class_getName to avoid string allocation)
+    if (class_getName([pageView class])[0] == '_') {
         return;
     }
 
@@ -1173,9 +1169,7 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     if (isDirectionReversed) { contentOffset.x += scrollViewPageWidth; }
     else { contentOffset.x -= scrollViewPageWidth; }
-    TOPagingViewPerformBlockWithoutLayout(view, ^{
-        view->_scrollView.contentOffset = contentOffset;
-    });
+    view->_scrollView.contentOffset = contentOffset;
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1225,9 +1219,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     if (isDirectionReversed) { contentOffset.x -= TOPagingViewScrollViewPageWidth(view); }
     else { contentOffset.x += scrollViewPageWidth; }
-    TOPagingViewPerformBlockWithoutLayout(view, ^{
-        view->_scrollView.contentOffset = contentOffset;
-    });
+    view->_scrollView.contentOffset = contentOffset;
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1310,9 +1302,9 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     CGFloat leftInset = insets.left;
     insets.left = insets.right;
     insets.right = leftInset;
-    TOPagingViewPerformBlockWithoutLayout(self, ^{
-        self->_scrollView.contentInset = insets;
-    });
+    _disableLayout = YES;
+    _scrollView.contentInset = insets;
+    _disableLayout = NO;
 }
 
 - (void)_playBounceAnimationInDirection:(TOPagingViewDirection)direction TOPAGINGVIEW_OBJC_DIRECT

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -72,6 +72,20 @@ typedef struct {
 @end
 
 // -----------------------------------------------------------------
+
+@class TOPagingView;
+
+/// A lightweight proxy that intercepts UIScrollViewDelegate calls.
+/// Uses NSProxy message forwarding to automatically forward all delegate methods
+/// to the external delegate, while intercepting scrollViewDidScroll: for internal use.
+/// This approach avoids manually implementing every UIScrollViewDelegate method.
+@interface TOScrollViewDelegateProxy : NSProxy <UIScrollViewDelegate>
+@property (nonatomic, weak) TOPagingView *pagingView;
+@property (nonatomic, weak) id<UIScrollViewDelegate> externalDelegate;
+- (instancetype)init;
+@end
+
+// -----------------------------------------------------------------
 // Convenience functions for easier mapping Objective-C and C constructs
 
 /// Convert an Objective-C class pointer into an NSValue that can be stored in a dictionary
@@ -130,6 +144,9 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 /// The animator used to play smooth transitions when turning pages
 @property (nonatomic, strong) UIViewPropertyAnimator *pageViewAnimator;
 
+/// The delegate proxy that handles scroll view delegate calls
+@property (nonatomic, strong) TOScrollViewDelegateProxy *scrollViewDelegateProxy;
+
 @end
 
 // -----------------------------------------------------------------
@@ -172,6 +189,10 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     self.clipsToBounds = YES; // The scroll view intentionally overlaps, so this view MUST clip.
     self.backgroundColor = [UIColor clearColor];
     
+    // Create and configure the scroll view delegate proxy
+    _scrollViewDelegateProxy = [[TOScrollViewDelegateProxy alloc] init];
+    _scrollViewDelegateProxy.pagingView = self;
+
     // Create and configure the scroll view
     _scrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
     [self _configureScrollView];
@@ -203,10 +224,11 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     // Never show the indicators
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.showsVerticalScrollIndicator = NO;
-    
-    // Register an observer to capture when the scroll view scrolls.
-    // Doing it this way lets us leave the delegate available for external objects to use.
-    [scrollView addObserver:self forKeyPath:@"contentOffset" options:0 context:(__bridge void *)self];
+
+    // Set our delegate proxy as the scroll view's delegate.
+    // The proxy forwards calls to an external delegate while also handling internal scroll tracking.
+    // This is faster than KVO (direct method dispatch vs KVO dictionary lookups).
+    scrollView.delegate = _scrollViewDelegateProxy;
 
     // Enable scrolling by clicking and dragging with the mouse
     // The only way to do this is via a private API. FB10593893 was filed to request this property is made public.
@@ -217,12 +239,6 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
             [scrollView performSelector:selector withObject:@(YES) afterDelay:0];
         }
     }
-}
-
-- (void)dealloc
-{
-    // Make sure to remove the observer before we deallocate otherwise it can potentially cause a crash.
-    [_scrollView removeObserver:self forKeyPath:@"contentOffset"];
 }
 
 #pragma mark - View Lifecycle -
@@ -313,24 +329,19 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     _scrollView.contentOffset = offset;
 }
 
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary<NSKeyValueChangeKey,id> *)change
-                       context:(void *)context
+/// Called by the scroll view delegate proxy when the scroll view scrolls.
+/// This replaces the KVO observer for better performance.
+- (void)_scrollViewDidScroll TOPAGINGVIEW_OBJC_DIRECT
 {
-    if ((__bridge id)context != self) {
-        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-    } else if (!_disableLayout) {
+    if (!_disableLayout) {
         TOPagingViewLayoutPages(self);
     }
 }
 
 - (void)_layoutPages TOPAGINGVIEW_OBJC_DIRECT
 {
-    // Since `TOPagingViewLayoutPages` is inlined, the only call to it should be
-    // in the KVO callback method. For all other calls (That don't require frame-tick precision),
-    // we can proxy through this method to call it.
-    [self observeValueForKeyPath:nil ofObject:nil change:nil context:(__bridge void *)self];
+    // Proxy through to the scroll handler for layout updates
+    [self _scrollViewDidScroll];
 }
 
 #pragma mark - Page Setup -
@@ -870,11 +881,9 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     void (^scrollDidEndDelegateBlock)(void) = ^{
         __strong __typeof(self) strongSelf = weakSelf;
         if (strongSelf == nil) { return; }
-        id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollView.delegate;
-        if (scrollViewDelegate) {
-            if ([scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
-                [scrollViewDelegate scrollViewDidEndScrollingAnimation:strongSelf->_scrollView];
-            }
+        id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollViewDelegateProxy.externalDelegate;
+        if ([scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
+            [scrollViewDelegate scrollViewDidEndScrollingAnimation:strongSelf->_scrollView];
         }
     };
 
@@ -1042,11 +1051,9 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         [strongSelf fetchAdjacentPagesIfAvailable];
 
         // If the scroll view delegate was set, tell it the animation completed
-        id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollView.delegate;
-        if (scrollViewDelegate) {
-            if ([scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
-                [scrollViewDelegate scrollViewDidEndScrollingAnimation:strongSelf->_scrollView];
-            }
+        id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollViewDelegateProxy.externalDelegate;
+        if ([scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
+            [scrollViewDelegate scrollViewDidEndScrollingAnimation:strongSelf->_scrollView];
         }
     };
 
@@ -1540,6 +1547,92 @@ static inline CGRect TOPagingViewLeftPageFrame(TOPagingView *view)
 static inline CGRect TOPagingViewRightPageFrame(TOPagingView *view)
 {
     return CGRectOffset(view.bounds, (TOPagingViewScrollViewPageWidth(view) * 2.0f) + (view->_pageSpacing * 0.5f), 0.0f);
+}
+
+#pragma mark - Scroll View Delegate Accessor -
+
+- (void)setScrollViewDelegate:(id<UIScrollViewDelegate>)scrollViewDelegate
+{
+    _scrollViewDelegateProxy.externalDelegate = scrollViewDelegate;
+}
+
+- (id<UIScrollViewDelegate>)scrollViewDelegate
+{
+    return _scrollViewDelegateProxy.externalDelegate;
+}
+
+@end
+
+// -----------------------------------------------------------------
+
+#pragma mark - Scroll View Delegate Proxy Implementation -
+
+/// The one selector we intercept to notify the paging view of scroll events.
+static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
+    return sel == @selector(scrollViewDidScroll:);
+}
+
+@implementation TOScrollViewDelegateProxy
+
+- (instancetype)init
+{
+    // NSProxy doesn't have a default -init, so we just return self
+    return self;
+}
+
+#pragma mark - Intercepted Method
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    // Notify the paging view of scroll changes
+    [_pagingView _scrollViewDidScroll];
+
+    // Forward to external delegate
+    if ([_externalDelegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
+        [_externalDelegate scrollViewDidScroll:scrollView];
+    }
+}
+
+#pragma mark - NSProxy Message Forwarding
+
+- (BOOL)respondsToSelector:(SEL)sel
+{
+    // We always respond to the intercepted selector
+    if (TOScrollViewDelegateProxyIsInterceptedSelector(sel)) {
+        return YES;
+    }
+    // Otherwise, forward to external delegate
+    return [_externalDelegate respondsToSelector:sel];
+}
+
+- (id)forwardingTargetForSelector:(SEL)sel
+{
+    // For non-intercepted selectors, forward directly to external delegate.
+    // This is the fast path - no NSInvocation boxing needed.
+    if (!TOScrollViewDelegateProxyIsInterceptedSelector(sel)) {
+        return _externalDelegate;
+    }
+    return nil;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+    // Try to get signature from external delegate
+    NSMethodSignature *signature = [(NSObject *)_externalDelegate methodSignatureForSelector:sel];
+    if (signature) {
+        return signature;
+    }
+    // Fallback: return a void signature to avoid crashing on unknown selectors
+    return [NSMethodSignature signatureWithObjCTypes:"v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    // This is the slow path, only used if forwardingTargetForSelector: returns nil
+    // and the method wasn't intercepted. Forward to external delegate if it responds.
+    if ([_externalDelegate respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:_externalDelegate];
+    }
 }
 
 @end

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1,7 +1,7 @@
 //
 //  TOPagingView.m
 //
-//  Copyright 2018-2023 Timothy Oliver. All rights reserved.
+//  Copyright 2018-2026 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
I asked Claude to review this repo for any potential low-effort performance enhancements it could find.

It pointed out that using KVO to observe the scroll view was potentially much more inefficient than simply using the scroll view's delegate, and that a variety of other code was performing allocations on each loop tick that could be optimized away.

This PR adds in those changes.