### PR TITLE
Replace the pre-canned page turn animation with a dynamically animated one

### DIFF
--- a/TOPagingView.xcodeproj/project.pbxproj
+++ b/TOPagingView.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -186,7 +186,8 @@
 		22C31613242899AA0063F6A6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1330;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 2640;
 				ORGANIZATIONNAME = "Tim Oliver";
 				TargetAttributes = {
 					22AD8C13284B25C6009F6265 = {
@@ -325,7 +326,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -334,7 +334,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -374,8 +373,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -395,6 +396,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Debug;
 		};
@@ -433,8 +435,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -447,6 +451,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -456,7 +461,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -479,7 +483,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -502,7 +505,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				INFOPLIST_FILE = TOPagingViewTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -522,7 +524,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				INFOPLIST_FILE = TOPagingViewTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/TOPagingView.xcodeproj/project.pbxproj
+++ b/TOPagingView.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		22C31631242899AB0063F6A6 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 22C31630242899AB0063F6A6 /* main.m */; };
 		22C3163B242899AB0063F6A6 /* TODynamicPageViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 22C3163A242899AB0063F6A6 /* TODynamicPageViewTests.m */; };
 		22C3167F242A40F80063F6A6 /* TOPagingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 22C3167E242A40F80063F6A6 /* TOPagingView.m */; };
+		22D4A7B3293F5E8A00B1C2D3 /* TOPagingViewAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 22D4A7B2293F5E8A00B1C2D3 /* TOPagingViewAnimator.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,8 @@
 		22C3163C242899AB0063F6A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22C3167D242A40F80063F6A6 /* TOPagingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOPagingView.h; sourceTree = "<group>"; };
 		22C3167E242A40F80063F6A6 /* TOPagingView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOPagingView.m; sourceTree = "<group>"; };
+		22D4A7B1293F5E8A00B1C2D3 /* TOPagingViewAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOPagingViewAnimator.h; sourceTree = "<group>"; };
+		22D4A7B2293F5E8A00B1C2D3 /* TOPagingViewAnimator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOPagingViewAnimator.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +135,8 @@
 			children = (
 				22C3167D242A40F80063F6A6 /* TOPagingView.h */,
 				22C3167E242A40F80063F6A6 /* TOPagingView.m */,
+				22D4A7B1293F5E8A00B1C2D3 /* TOPagingViewAnimator.h */,
+				22D4A7B2293F5E8A00B1C2D3 /* TOPagingViewAnimator.m */,
 			);
 			path = TOPagingView;
 			sourceTree = "<group>";
@@ -281,6 +286,7 @@
 				22C31620242899AA0063F6A6 /* TOAppDelegate.m in Sources */,
 				22ADED24242B2ADD004A7854 /* TOTestPageView.m in Sources */,
 				22C3167F242A40F80063F6A6 /* TOPagingView.m in Sources */,
+				22D4A7B3293F5E8A00B1C2D3 /* TOPagingViewAnimator.m in Sources */,
 				22C31631242899AB0063F6A6 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TOPagingView.xcodeproj/project.pbxproj
+++ b/TOPagingView.xcodeproj/project.pbxproj
@@ -513,7 +513,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.TOPagingViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOPagingView.app/TOPagingView";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOPagingViewExample.app/TOPagingViewExample";
 			};
 			name = Debug;
 		};
@@ -533,7 +533,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.TOPagingViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOPagingView.app/TOPagingView";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TOPagingViewExample.app/TOPagingViewExample";
 			};
 			name = Release;
 		};

--- a/TOPagingView.xcodeproj/project.pbxproj
+++ b/TOPagingView.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		227BEDFA27AC1867009D6B6D /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 227BEDF927AC1867009D6B6D /* CHANGELOG.md */; };
+		24F0A0012F24000100000001 /* TOPagingViewUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F0A0042F24000100000001 /* TOPagingViewUITests.m */; };
 		22ADED24242B2ADD004A7854 /* TOTestPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 22ADED23242B2ADD004A7854 /* TOTestPageView.m */; };
 		22C31620242899AA0063F6A6 /* TOAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 22C3161F242899AA0063F6A6 /* TOAppDelegate.m */; };
 		22C31626242899AA0063F6A6 /* TOViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 22C31625242899AA0063F6A6 /* TOViewController.m */; };
@@ -33,6 +34,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		24F0A0022F24000100000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 22C31613242899AA0063F6A6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 22C3161A242899AA0063F6A6;
+			remoteInfo = TOPagingViewExample;
+		};
 		22C31637242899AB0063F6A6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 22C31613242899AA0063F6A6 /* Project object */;
@@ -46,6 +54,9 @@
 		227BEDF927AC1867009D6B6D /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		227BEDFB27AC186F009D6B6D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		227BEDFC27AC1879009D6B6D /* TOPagingView.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = TOPagingView.podspec; sourceTree = "<group>"; };
+		24F0A0032F24000100000001 /* TOPagingViewUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TOPagingViewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		24F0A0042F24000100000001 /* TOPagingViewUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOPagingViewUITests.m; sourceTree = "<group>"; };
+		24F0A0052F24000100000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22ADED22242B2ADD004A7854 /* TOTestPageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOTestPageView.h; sourceTree = "<group>"; };
 		22ADED23242B2ADD004A7854 /* TOTestPageView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOTestPageView.m; sourceTree = "<group>"; };
 		22C3161B242899AA0063F6A6 /* TOPagingViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TOPagingViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,6 +77,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		24F0A0082F24000100000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		22C31618242899AA0063F6A6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -89,6 +107,7 @@
 				22C3167C242A3C460063F6A6 /* TOPagingView */,
 				22C3161D242899AA0063F6A6 /* TOPagingViewExample */,
 				22C31639242899AB0063F6A6 /* TOPagingViewTests */,
+				24F0A0062F24000100000001 /* TOPagingViewUITests */,
 				227BEDFC27AC1879009D6B6D /* TOPagingView.podspec */,
 				227BEDFB27AC186F009D6B6D /* README.md */,
 				227BEDF927AC1867009D6B6D /* CHANGELOG.md */,
@@ -101,6 +120,7 @@
 			children = (
 				22C3161B242899AA0063F6A6 /* TOPagingViewExample.app */,
 				22C31636242899AB0063F6A6 /* TOPagingViewTests.xctest */,
+				24F0A0032F24000100000001 /* TOPagingViewUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,6 +150,15 @@
 			path = TOPagingViewTests;
 			sourceTree = "<group>";
 		};
+		24F0A0062F24000100000001 /* TOPagingViewUITests */ = {
+			isa = PBXGroup;
+			children = (
+				24F0A0042F24000100000001 /* TOPagingViewUITests.m */,
+				24F0A0052F24000100000001 /* Info.plist */,
+			);
+			path = TOPagingViewUITests;
+			sourceTree = "<group>";
+		};
 		22C3167C242A3C460063F6A6 /* TOPagingView */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +173,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		24F0A0072F24000100000001 /* TOPagingViewUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 24F0A00E2F24000100000001 /* Build configuration list for PBXNativeTarget "TOPagingViewUITests" */;
+			buildPhases = (
+				24F0A00A2F24000100000001 /* Sources */,
+				24F0A0082F24000100000001 /* Frameworks */,
+				24F0A0092F24000100000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				24F0A00B2F24000100000001 /* PBXTargetDependency */,
+			);
+			name = TOPagingViewUITests;
+			productName = TOPagingViewUITests;
+			productReference = 24F0A0032F24000100000001 /* TOPagingViewUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		22C3161A242899AA0063F6A6 /* TOPagingViewExample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 22C3163F242899AB0063F6A6 /* Build configuration list for PBXNativeTarget "TOPagingViewExample" */;
@@ -200,6 +247,10 @@
 						CreatedOnToolsVersion = 11.3.1;
 						TestTargetID = 22C3161A242899AA0063F6A6;
 					};
+					24F0A0072F24000100000001 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 22C3161A242899AA0063F6A6;
+					};
 				};
 			};
 			buildConfigurationList = 22C31616242899AA0063F6A6 /* Build configuration list for PBXProject "TOPagingView" */;
@@ -217,12 +268,20 @@
 			targets = (
 				22C3161A242899AA0063F6A6 /* TOPagingViewExample */,
 				22C31635242899AB0063F6A6 /* TOPagingViewTests */,
+				24F0A0072F24000100000001 /* TOPagingViewUITests */,
 				22AD8C13284B25C6009F6265 /* OCLint */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		24F0A0092F24000100000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		22C31619242899AA0063F6A6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -279,6 +338,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		24F0A00A2F24000100000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24F0A0012F24000100000001 /* TOPagingViewUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		22C31617242899AA0063F6A6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -303,6 +370,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		24F0A00B2F24000100000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 22C3161A242899AA0063F6A6 /* TOPagingViewExample */;
+			targetProxy = 24F0A0022F24000100000001 /* PBXContainerItemProxy */;
+		};
 		22C31638242899AB0063F6A6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 22C3161A242899AA0063F6A6 /* TOPagingViewExample */;
@@ -538,6 +610,32 @@
 			};
 			name = Release;
 		};
+		24F0A00C2F24000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TOPagingViewUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.TOPagingViewUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TOPagingViewExample;
+			};
+			name = Debug;
+		};
+		24F0A00D2F24000100000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TOPagingViewUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.TOPagingViewUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TOPagingViewExample;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -573,6 +671,15 @@
 			buildConfigurations = (
 				22C31643242899AB0063F6A6 /* Debug */,
 				22C31644242899AB0063F6A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		24F0A00E2F24000100000001 /* Build configuration list for PBXNativeTarget "TOPagingViewUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				24F0A00C2F24000100000001 /* Debug */,
+				24F0A00D2F24000100000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
+++ b/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:TOPagingView.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24F0A0072F24000100000001"
+               BuildableName = "TOPagingViewUITests.xctest"
+               BlueprintName = "TOPagingViewUITests"
+               ReferencedContainer = "container:TOPagingView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
+++ b/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
+++ b/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewExample.xcscheme
@@ -38,16 +38,6 @@
                ReferencedContainer = "container:TOPagingView.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "24F0A0072F24000100000001"
-               BuildableName = "TOPagingViewUITests.xctest"
-               BlueprintName = "TOPagingViewUITests"
-               ReferencedContainer = "container:TOPagingView.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewUITests.xcscheme
+++ b/TOPagingView.xcodeproj/xcshareddata/xcschemes/TOPagingViewUITests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24F0A0072F24000100000001"
+               BuildableName = "TOPagingViewUITests.xctest"
+               BlueprintName = "TOPagingViewUITests"
+               ReferencedContainer = "container:TOPagingView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TOPagingView/TOPagingView.h
+++ b/TOPagingView/TOPagingView.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, TOPagingViewPageType) {
     /// The current page that will be visible on screen initially.
     TOPagingViewPageTypeCurrent,
 
-    ///The next page sequentially after the current page.
+    /// The next page sequentially after the current page.
     TOPagingViewPageTypeNext,
 
     /// The previous page sequentially before the current page.
@@ -71,7 +71,7 @@ NS_SWIFT_NAME(PagingViewPage)
 - (NSString *)uniqueIdentifier;
 
 /// Called just before the page object is removed from the visible page set,
-/// and re-enqueud by the data source.
+/// and re-enqueued by the data source.
 ///
 /// Use this method to return the page to a default state, and to clear out any
 /// references to memory-heavy objects like images.
@@ -114,7 +114,7 @@ NS_SWIFT_NAME(PagingViewDataDelegate)
 
 @optional
 
-/// Called when a transaction has started moving in a direction (eg, the user has
+/// Called when a transition has started moving in a direction (eg, the user has
 /// started swiping in a direction, or an animation is about to start) that can potentially
 /// end in a page transition. Use this to start preloading content in that direction.
 /// @param pagingView The calling paging view instance.

--- a/TOPagingView/TOPagingView.h
+++ b/TOPagingView/TOPagingView.h
@@ -128,7 +128,7 @@ NS_SWIFT_NAME(PagingViewDataDelegate)
 - (void)pagingView:(TOPagingView *)pagingView didTurnToPageOfType:(TOPagingViewPageType)type;
 
 /// Called when dynamic page direction is enabled, and the user just swiped off the initial page in either
-/// direction, effectively committing to a new page direction. Use this to update any UI or persist the new direction
+/// direction, effectively committing to a new page direction. Use this to update any UI or persist the new direction.
 /// @param pagingView The calling paging view instance.
 /// @param direction The new direction in which the pages are flowing.
 - (void)pagingView:(TOPagingView *)pagingView didChangeToPageDirection:(TOPagingViewDirection)direction;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -304,6 +304,13 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     [self reload];
 }
 
+- (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer {
+    if ([gestureRecognizer isKindOfClass:UITapGestureRecognizer.class]) {
+        [_scrollView.panGestureRecognizer requireGestureRecognizerToFail:gestureRecognizer];
+    }
+    [super addGestureRecognizer:gestureRecognizer];
+}
+
 #pragma mark - Scroll View Management -
 
 - (void)_updateContentSize TOPAGINGVIEW_OBJC_DIRECT

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -898,7 +898,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Animate the page turn via CADisplayLink toward the predetermined edge.
+    // Animate the page turn via CADisplayLink using logical distance and per-frame deltas.
     _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
     [_pageAnimator turnToPageInDirection:direction];
 }

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1121,7 +1121,6 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     if (isDirectionReversed) { contentOffset.x += scrollViewPageWidth; }
     else { contentOffset.x -= scrollViewPageWidth; }
     view->_scrollView.contentOffset = contentOffset;
-    [view->_pageAnimator didTransition];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1172,7 +1171,6 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     if (isDirectionReversed) { contentOffset.x -= TOPagingViewScrollViewPageWidth(view); }
     else { contentOffset.x += scrollViewPageWidth; }
     view->_scrollView.contentOffset = contentOffset;
-    [view->_pageAnimator didTransition];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -21,6 +21,7 @@
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "TOPagingView.h"
+#import "TOPagingViewAnimator.h"
 #import <objc/runtime.h>
 
 /// Mark methods as being statically called to increase performance
@@ -38,10 +39,7 @@ static const CGFloat kTOPagingViewPageSlotCount = 3.0f;
 static const CGFloat kTOPagingViewBumperWidthCompact = 48.0f;
 static const CGFloat kTOPagingViewBumperWidthRegular = 96.0f;
 
-/// The timing parameters when playing a precanned transition animation.
-static const CFTimeInterval kTOPagingViewAnimationDuration = 0.4f;
-static const CGPoint kTOPagingViewAnimationControlPoint1 = (CGPoint){0.3f, 0.9f};
-static const CGPoint kTOPagingViewAnimationControlPoint2 = (CGPoint){0.45f, 1.0f};
+/// The animation options used for the bounce animation.
 static const NSInteger kTOPagingViewAnimationOptions = (UIViewAnimationOptionAllowUserInteraction);
 
 // -----------------------------------------------------------------
@@ -142,7 +140,7 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 @property (nonatomic, assign) BOOL needsPreviousPage;
 
 /// The animator used to play smooth transitions when turning pages
-@property (nonatomic, strong) UIViewPropertyAnimator *pageViewAnimator;
+@property (nonatomic, strong) TOPagingViewAnimator *pageAnimator;
 
 /// The delegate proxy that handles scroll view delegate calls
 @property (nonatomic, strong) TOScrollViewDelegateProxy *scrollViewDelegateProxy;
@@ -199,10 +197,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     [self addSubview:_scrollView];
 
     // Configure the page view animator
-    UICubicTimingParameters *const cubicTiming = [[UICubicTimingParameters alloc] initWithControlPoint1:kTOPagingViewAnimationControlPoint1
-                                                                                    controlPoint2:kTOPagingViewAnimationControlPoint2];
-    _pageViewAnimator = [[UIViewPropertyAnimator alloc] initWithDuration:kTOPagingViewAnimationDuration
-                                                        timingParameters:cubicTiming];
+    _pageAnimator = [[TOPagingViewAnimator alloc] init];
+    _pageAnimator.scrollView = _scrollView;
 }
 
 - (void)_configureScrollView TOPAGINGVIEW_OBJC_DIRECT
@@ -846,21 +842,22 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
 
 - (void)_turnToPageInDirection:(UIRectEdge)direction animated:(BOOL)animated TOPAGINGVIEW_OBJC_DIRECT
 {
-    // Determine the direction to animate towards
-    CGFloat offset = 0.0f;
-    if (direction == UIRectEdgeRight) {
-        offset = _scrollView.contentSize.width - TOPagingViewScrollViewPageWidth(self);
-    }
-
     UIScrollView *const scrollView = _scrollView;
+    const BOOL isLeftDirection = (direction == UIRectEdgeLeft);
 
     // Determine the direction we're heading for the delegate
-    const BOOL isLeftDirection = (offset < FLT_EPSILON);
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL isDetectingDirection = _isDynamicPageDirectionEnabled
                                         && TOPagingViewIsInitialPageForPageView(self, _currentPageView);
     const BOOL isPreviousPage = !isDetectingDirection && ((!isDirectionReversed && isLeftDirection) ||
                                                           (isDirectionReversed && !isLeftDirection));
+
+    // If we're already animating toward the last available page, don't extend the animation
+    if (_pageAnimator.isAnimating) {
+        if ((isPreviousPage && !_hasPreviousPage) || (!isPreviousPage && !_hasNextPage)) {
+            return;
+        }
+    }
 
     // Send a delegate event stating the page is about to turn
     if (_delegateFlags.delegateWillTurnToPage) {
@@ -868,17 +865,24 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         [_delegate pagingView:self willTurnToPageOfType:type];
     }
 
-    // If we're not animating, re-enable layout,
-    // and then set the offset to the target
+    // If we're not animating, set the offset to the target directly
     if (animated == NO) {
-        scrollView.contentOffset = (CGPoint){offset, 0.0f};
+        CGFloat targetOffset = 0.0f;
+        if (direction == UIRectEdgeRight) {
+            targetOffset = scrollView.contentSize.width - TOPagingViewScrollViewPageWidth(self);
+        }
+        scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
         return;
     }
 
-    // If the scroll view delegate was set, define this block we can use when the animations completes.
-    // (Whether it succeeded, or got canceled)
+    // If the scroll view is decelerating from a swipe, cancel it.
+    if (scrollView.isDecelerating) {
+        [scrollView setContentOffset:scrollView.contentOffset animated:NO];
+    }
+
+    // Set up the completion handler to notify the external scroll view delegate
     __weak __typeof(self) weakSelf = self;
-    void (^scrollDidEndDelegateBlock)(void) = ^{
+    _pageAnimator.completionHandler = ^{
         __strong __typeof(self) strongSelf = weakSelf;
         if (strongSelf == nil) { return; }
         id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollViewDelegateProxy.externalDelegate;
@@ -887,89 +891,25 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // If the scroll view is decelerating from a swipe, cancel it.
-    if (scrollView.isDecelerating) {
-        [scrollView setContentOffset:scrollView.contentOffset animated:NO];
-    }
-
-    // If we're already in an animation, we can't queue up a new animation
-    // before the old one completes, otherwise we'll overshoot the pages and cause visual glitching.
-    // (There might be a better way to implement this down the line)
-    if (scrollView.layer.animationKeys.count) {
-        // If we're already in an animation that is moving towards the last a page
-        // with no page coming after it, cancel out to let the animation completely fluidly.
-        if ((isPreviousPage && !_hasPreviousPage) || (!isPreviousPage && !_hasNextPage)) {
-            return;
-        }
-
-        // Cancel the current animation
-        [scrollView.layer removeAllAnimations];
-
-        // Trigger the completed delegate
-        scrollDidEndDelegateBlock();
-
-        // Re-enable layout so when we change the content offset, we'll reset all of the pages
-        _disableLayout = NO;
-    }
-
-    // Move the scroll view to the target offset, which will trigger a layout.
-    // This will update all of the page views, and trigger the delegate with the right state
-    scrollView.contentOffset = (CGPoint){offset, 0.0f};
-
-    // Disable layout during this animation as we'll manually control layout here
-    _disableLayout = YES;
-
-    // The scroll view will now be centered, so lets capture this destination
-    const CGPoint destOffset = scrollView.contentOffset;
-
-    // Move the scroll view back to where it should be so we can perform the animation
-    if (offset < FLT_EPSILON) {
-        scrollView.contentOffset = (CGPoint){TOPagingViewScrollViewPageWidth(self) * 2.0f, 0.0f};
-    } else {
-        scrollView.contentOffset = (CGPoint){0.0f, 0.0f};
-    }
-
-    // Define animation parameters
-    id animationBlock = ^{
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) { return; }
-        strongSelf->_scrollView.contentOffset = destOffset;
-    };
-
-    id completionBlock = ^(UIViewAnimatingPosition finalPosition) {
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) { return; }
-
-        // Re-enable automatic layout
-        strongSelf->_disableLayout = NO;
-
-        // Perform a sanity layout just in case
-        // (But in most cases, this should be a no-op)
-        [strongSelf _layoutPages];
-
-        // Trigger the animation completed delgate
-        scrollDidEndDelegateBlock();
-    };
-
-    // Perform a very tight transition animation to the next page
-    [_pageViewAnimator addAnimations:animationBlock];
-    [_pageViewAnimator addCompletion:completionBlock];
-    [_pageViewAnimator startAnimation];
+    // Animate by one page width in the target direction via CADisplayLink.
+    // The per-frame deltas allow the paging view's scroll handling to process
+    // page transitions naturally. If already animating, the remaining distance
+    // is aggregated with the new page turn and the timer restarts.
+    const CGFloat distance = isLeftDirection ? -TOPagingViewScrollViewPageWidth(self) : TOPagingViewScrollViewPageWidth(self);
+    [_pageAnimator animateDistance:distance];
 }
 
 - (void)_skipToNewPageInDirection:(UIRectEdge)direction animated:(BOOL)animated TOPAGINGVIEW_OBJC_DIRECT
 {
+    // Stop any ongoing animation
+    [_pageAnimator stopAnimation];
+
     // Disable the layout since we'll handle everything beyond this point
     _disableLayout = YES;
 
     // If the scroll view is decelerating from a swipe, cancel it.
     if (_scrollView.isDecelerating) {
         [_scrollView setContentOffset:_scrollView.contentOffset animated:NO];
-    }
-
-    // If we're already in an animation, cancel it and reset the position
-    if (_scrollView.layer.animationKeys.count > 0) {
-        [_scrollView.layer removeAllAnimations];
     }
 
     // Reclaim the next and previous pages since these will always need to be regenerated
@@ -980,9 +920,6 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     UIView<TOPagingViewPage> *newPageView = [_dataSource pagingView:self
                                                     pageViewForType:TOPagingViewPageTypeCurrent
                                                     currentPageView:_currentPageView];
-
-    // Set the destination point regardless of animation to them middle
-    CGPoint destinationPoint = (CGPoint){TOPagingViewScrollViewPageWidth(self), 0.0f}; // Destination is always the middle
 
     // Zero out the adjacent pages and set the
     // next/previous flags to ensure we'll query for new pages
@@ -1005,7 +942,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         _disableLayout = NO;
 
         // Re-set the offset to the middle
-        _scrollView.contentOffset = destinationPoint;
+        _scrollView.contentOffset = (CGPoint){TOPagingViewScrollViewPageWidth(self), 0.0f};
 
         // Trigger requesting replacement adjacent pages
         [self fetchAdjacentPagesIfAvailable];
@@ -1027,21 +964,17 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     _currentPageView.frame = TOPagingViewCurrentPageFrame(self);
     TOPagingViewInsertPageView(self, _currentPageView);
 
-    // Define the animation block, making sure not to cause any retain cycles
-    __weak __typeof(self) weakSelf = self;
-    id animationBlock = ^{
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) { return; }
-        strongSelf->_scrollView.contentOffset = destinationPoint;
-    };
+    // Calculate the animation distance toward the center
+    const CGFloat distance = (direction == UIRectEdgeLeft) ? -TOPagingViewScrollViewPageWidth(self) : TOPagingViewScrollViewPageWidth(self);
 
-    // Define the completion block
-    id completionBlock = ^(UIViewAnimatingPosition finalPosition) {
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
+    // Set up the completion handler
+    __weak __typeof(self) weakSelf = self;
+    _pageAnimator.completionHandler = ^{
+        __strong __typeof(self) strongSelf = weakSelf;
         if (!strongSelf) { return; }
 
         // Remove the previous page
-        TOPagingViewReclaimPageView(self, self->_previousPageView);
+        TOPagingViewReclaimPageView(strongSelf, strongSelf->_previousPageView);
         strongSelf->_previousPageView = nil;
 
         // Re-enable layout
@@ -1057,10 +990,8 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Perform a very tight transition animation to the target page
-    [_pageViewAnimator addAnimations:animationBlock];
-    [_pageViewAnimator addCompletion:completionBlock];
-    [_pageViewAnimator startAnimation];
+    // Perform the skip animation via CADisplayLink
+    [_pageAnimator animateDistance:distance];
 }
 
 - (nullable __kindof UIView *)pageViewForUniqueIdentifier:(NSString *)identifier

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -84,7 +84,7 @@ typedef struct {
 @end
 
 @interface TOPagingViewAnimator (Internal)
-- (void)didTransition;
+- (void)didTransitionWithOffset:(CGFloat)offset;
 @end
 
 // -----------------------------------------------------------------
@@ -1115,13 +1115,17 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     [view setNeedsLayout];
 
     // Move the scroll view back one segment
+    const CGFloat previousOffsetX = view->_scrollView.contentOffset.x;
     CGPoint contentOffset = view->_scrollView.contentOffset;
     const CGFloat scrollViewPageWidth = TOPagingViewScrollViewPageWidth(view);
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? 1.0f : -1.0f);
     contentOffset.x += offset;
+    if (view->_pageAnimator.isAnimating) {
+        contentOffset.x = scrollViewPageWidth;
+    }
     view->_scrollView.contentOffset = contentOffset;
-    [view->_pageAnimator didTransitionWithOffset:offset];
+    [view->_pageAnimator didTransitionWithOffset:(contentOffset.x - previousOffsetX)];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1166,13 +1170,17 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     [view setNeedsLayout];
 
     // Move the scroll view forward one segment
+    const CGFloat previousOffsetX = view->_scrollView.contentOffset.x;
     CGPoint contentOffset = view->_scrollView.contentOffset;
     const CGFloat scrollViewPageWidth = TOPagingViewScrollViewPageWidth(view);
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? -1.0f : 1.0f);
     contentOffset.x += offset;
+    if (view->_pageAnimator.isAnimating) {
+        contentOffset.x = scrollViewPageWidth;
+    }
     view->_scrollView.contentOffset = contentOffset;
-    [view->_pageAnimator didTransitionWithOffset:offset];
+    [view->_pageAnimator didTransitionWithOffset:(contentOffset.x - previousOffsetX)];
     
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -24,10 +24,6 @@
 #import "TOPagingViewAnimator.h"
 #import <objc/runtime.h>
 
-@interface TOPagingViewAnimator ()
-- (void)animateOffset:(CGFloat)distance;
-@end
-
 /// Mark methods as being statically called to increase performance
 #define TOPAGINGVIEW_OBJC_DIRECT __attribute__((objc_direct))
 
@@ -870,12 +866,9 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     }
 
-    // Only send the willTurn delegate for the first turn in a sequence.
-    // For subsequent taps during an animation, the animator will notify
-    // us via pageTransitionHandler when each page boundary is crossed,
-    // and we fire willTurn for the next page at that point.
+    // Fire the willTurn delegate for each requested animated turn.
     const TOPagingViewPageType type = (isPreviousPage ? TOPagingViewPageTypePrevious : TOPagingViewPageTypeNext);
-    if (!_pageAnimator.isAnimating && _delegateFlags.delegateWillTurnToPage) {
+    if (_delegateFlags.delegateWillTurnToPage) {
         [_delegate pagingView:self willTurnToPageOfType:type];
     }
 
@@ -905,20 +898,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Set up the page transition handler — called after each page boundary
-    // crossing when more turns are still pending. This is where we fire
-    // willTurnToPageOfType: for the next page at the correct moment.
-    _pageAnimator.pageTransitionHandler = ^{
-        __strong __typeof(self) strongSelf = weakSelf;
-        if (strongSelf == nil) { return; }
-        if (strongSelf->_delegateFlags.delegateWillTurnToPage) {
-            [strongSelf->_delegate pagingView:strongSelf willTurnToPageOfType:type];
-        }
-    };
-
-    // Animate the page turn via CADisplayLink. The animator determines the
-    // destination from the page width and the number of turns already queued.
-    // If already animating, the turn count increments and the timer restarts.
+    // Animate the page turn via CADisplayLink toward the predetermined edge.
     _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
     [_pageAnimator turnToPageInDirection:direction];
 }
@@ -927,6 +907,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
 {
     // Stop any ongoing animation
     [_pageAnimator stopAnimation];
+    _pageAnimator.completionHandler = nil;
 
     // Disable the layout since we'll handle everything beyond this point
     _disableLayout = YES;
@@ -988,15 +969,9 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     _currentPageView.frame = TOPagingViewCurrentPageFrame(self);
     TOPagingViewInsertPageView(self, _currentPageView);
 
-    // Calculate the animation distance toward the center.
-    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
-    const CGFloat distance = (direction == UIRectEdgeLeft) ? -pageWidth : pageWidth;
-    _pageAnimator.pageWidth = pageWidth;
-    _pageAnimator.pageTransitionHandler = nil;
-
     // Set up the completion handler
     __weak __typeof(self) weakSelf = self;
-    _pageAnimator.completionHandler = ^{
+    void (^completionBlock)(BOOL) = ^(BOOL finished) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (!strongSelf) { return; }
 
@@ -1017,8 +992,15 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Perform the skip animation as a one-shot offset change.
-    [_pageAnimator animateOffset:distance];
+    // Animate the scroll view back to the center slot with a standard view animation.
+    const CGPoint centerOffset = (CGPoint){TOPagingViewScrollViewPageWidth(self), 0.0f};
+    [UIView animateWithDuration:_pageAnimator.duration
+                          delay:0.0f
+                        options:kTOPagingViewAnimationOptions
+                     animations:^{
+                         [self->_scrollView setContentOffset:centerOffset animated:NO];
+                     }
+                     completion:completionBlock];
 }
 
 - (nullable __kindof UIView *)pageViewForUniqueIdentifier:(NSString *)identifier

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -341,13 +341,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 /// This replaces the KVO observer for better performance.
 - (void)_scrollViewDidScroll TOPAGINGVIEW_OBJC_DIRECT
 {
-    if (_scrollView.contentOffset.x == 1173) {
-        NSLog(@"We");
-    }
-    
-    if (!_disableLayout) {
-        TOPagingViewLayoutPages(self);
-    }
+    if (_disableLayout) { return; }
+    TOPagingViewLayoutPages(self);
 }
 
 /// Called by the scroll view delegate proxy when the user begins dragging.
@@ -751,7 +746,10 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
     const CGPoint offset = view->_scrollView.contentOffset;
     const CGFloat segmentWidth = TOPagingViewScrollViewPageWidth(view);
     const CGSize contentSize = view->_scrollView.contentSize;
+    const UIRectEdge direction = view->_pageAnimator.direction;
     const BOOL isAnimating = view->_pageAnimator.isAnimating;
+    const BOOL isAnimatingRight = isAnimating && direction == UIRectEdgeRight;
+    const BOOL isAnimatingLeft = isAnimating && direction == UIRectEdgeLeft;
     const CGFloat offsetX = offset.x;
 
     // By default, we only perform transitions when a new page has fully landed on screen.
@@ -760,8 +758,8 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
     // When the page animator is active, we need to transition sooner than the far edge.
     // Treat the center slot as the "arming" point, and only fire when we first cross away
     // from it so we don't repeatedly transition while remaining on the same side.
-    const CGFloat rightHandThreshold = isAnimating ? segmentWidth + 1.0f : contentSize.width - segmentWidth;
-    const CGFloat leftHandThreshold = isAnimating ? segmentWidth - 1.0f : FLT_EPSILON;
+    const CGFloat rightHandThreshold = isAnimatingRight ? segmentWidth + 1.0f : contentSize.width - segmentWidth;
+    const CGFloat leftHandThreshold = isAnimatingLeft ? segmentWidth - 1.0f : FLT_EPSILON;
 
     // Check if we went over the right-hand threshold to start transitioning the pages
     if ((!isReversed && offsetX >= rightHandThreshold) || (isReversed && offsetX <= leftHandThreshold)) {
@@ -1561,11 +1559,6 @@ static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-//    NSLog(@"----");
-//    NSLog(@"scroll %f", scrollView.contentOffset.x);
-//    NSLog(@"%@", NSThread.callStackSymbols);
-//    NSLog(@"----");
-    
     // Notify the paging view of scroll changes
     [_pagingView _scrollViewDidScroll];
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -147,10 +147,6 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 @property (nonatomic, assign) CGFloat draggingOrigin;
 @property (nonatomic, assign) TOPagingViewPageType draggingDirectionType;
 
-/// State tracking for when the wrapped scroll view is decelerating.
-@property (nonatomic, assign) CGFloat scrollDecelerationOrigin;
-@property (nonatomic, assign, readwrite) UIRectEdge scrollDecelerationDirection;
-
 /// State tracking for offloading view configuration to another run-loop tick.
 @property (nonatomic, assign) BOOL needsNextPage;
 @property (nonatomic, assign) BOOL needsPreviousPage;
@@ -199,7 +195,6 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
                                                    valueOptions:NSPointerFunctionsStrongMemory];
     memset(&_delegateFlags, 0, sizeof(TOPagingViewDelegateFlags));
     _draggingOrigin = -CGFLOAT_MAX;
-    _scrollDecelerationOrigin = -CGFLOAT_MAX;
 
     // Configure the main properties of this view
     self.clipsToBounds = YES; // The scroll view intentionally overlaps, so this view MUST clip.
@@ -367,24 +362,12 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     if (_pageAnimator.isAnimating) {
         [_pageAnimator stopAnimation];
     }
-    [self _resetScrollDecelerationTracking];
 }
 
 - (void)_layoutPages TOPAGINGVIEW_OBJC_DIRECT
 {
     // Proxy through to the scroll handler for layout updates
     [self _scrollViewDidScroll];
-}
-
-- (BOOL)_scrollViewIsDeceleratingInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT
-{
-    return _scrollView.isDecelerating && _scrollDecelerationDirection == direction;
-}
-
-- (void)_resetScrollDecelerationTracking TOPAGINGVIEW_OBJC_DIRECT
-{
-    _scrollDecelerationOrigin = -CGFLOAT_MAX;
-    _scrollDecelerationDirection = UIRectEdgeNone;
 }
 
 #pragma mark - Page Setup -
@@ -604,13 +587,15 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (void)turnToLeftPageAnimated:(BOOL)animated
 {
+    const CGFloat offsetX = _scrollView.contentOffset.x;
+    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) ||
                              (!isDirectionReversed && _hasPreviousPage);
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasLeftPage && ![self _scrollViewIsDeceleratingInDirection:UIRectEdgeRight]) {
+    if (!hasLeftPage && offsetX < pageWidth) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
@@ -622,19 +607,20 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (void)turnToRightPageAnimated:(BOOL)animated
 {
+    const CGFloat offsetX = _scrollView.contentOffset.x;
+    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
                               (!isDirectionReversed && _hasNextPage);
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasRightPage && ![self _scrollViewIsDeceleratingInDirection:UIRectEdgeLeft]) {
+    if (!hasRightPage && offsetX >= pageWidth - FLT_EPSILON) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
     }
-
-    // Turn to the right side page
+    
     [self _turnToPageInDirection:UIRectEdgeRight animated:animated];
 }
 
@@ -671,9 +657,6 @@ static inline void TOPagingViewLayoutPages(TOPagingView *view) {
         && TOPagingViewIsInitialPageForPageView(view, view->_currentPageView)) {
         TOPagingViewHandleDynamicPageDirectionLayout(view);
     }
-
-    // Track deceleration direction before page transitions potentially recenter the scroll view.
-    TOPagingViewUpdateDecelerationInteractions(view);
 
     // Check the offset of the scroll view, and when it passes over
     // the mid point between two pages, perform the page transition
@@ -798,36 +781,6 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
         // Check if we're over the left threshold
         TOPagingViewTransitionOverToPreviousPage(view);
     }
-}
-
-static inline UIRectEdge TOPagingViewDirectionForOffsetDelta(CGFloat offset, CGFloat origin)
-{
-    if (offset < origin - FLT_EPSILON) { return UIRectEdgeLeft; }
-    if (offset > origin + FLT_EPSILON) { return UIRectEdgeRight; }
-    return UIRectEdgeNone;
-}
-
-static inline void TOPagingViewUpdateDecelerationInteractions(TOPagingView *view)
-{
-    if (!view->_scrollView.isDecelerating) {
-        if (view->_scrollDecelerationDirection != UIRectEdgeNone ||
-            view->_scrollDecelerationOrigin > -CGFLOAT_MAX) {
-            [view _resetScrollDecelerationTracking];
-        }
-        return;
-    }
-
-    const CGFloat offset = view->_scrollView.contentOffset.x;
-    if (view->_scrollDecelerationOrigin <= -CGFLOAT_MAX + FLT_EPSILON) {
-        view->_scrollDecelerationOrigin = offset;
-        return;
-    }
-
-    const UIRectEdge direction = TOPagingViewDirectionForOffsetDelta(offset, view->_scrollDecelerationOrigin);
-    if (direction != UIRectEdgeNone) {
-        view->_scrollDecelerationDirection = direction;
-    }
-    view->_scrollDecelerationOrigin = offset;
 }
 
 static inline void TOPagingViewUpdateDragInteractions(TOPagingView *view)
@@ -964,7 +917,6 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     // If the scroll view is decelerating from a swipe, cancel it.
     if (scrollView.isDecelerating) {
         [scrollView setContentOffset:scrollView.contentOffset animated:NO];
-        [self _resetScrollDecelerationTracking];
     }
 
     // Set up the completion handler to notify the external scroll view delegate
@@ -995,7 +947,6 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     // If the scroll view is decelerating from a swipe, cancel it.
     if (_scrollView.isDecelerating) {
         [_scrollView setContentOffset:_scrollView.contentOffset animated:NO];
-        [self _resetScrollDecelerationTracking];
     }
 
     // Reclaim the next and previous pages since these will always need to be regenerated
@@ -1205,9 +1156,6 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     if (view->_scrollView.isDragging) {
         view->_draggingOrigin = -CGFLOAT_MAX;
     }
-    if (view->_scrollView.isDecelerating) {
-        view->_scrollDecelerationOrigin = -CGFLOAT_MAX;
-    }
 
     view->_disableLayout = NO;
 }
@@ -1259,9 +1207,6 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
         view->_draggingOrigin = -CGFLOAT_MAX;
-    }
-    if (view->_scrollView.isDecelerating) {
-        view->_scrollDecelerationOrigin = -CGFLOAT_MAX;
     }
 
     view->_disableLayout = NO;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -580,8 +580,9 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) ||
                              (!isDirectionReversed && _hasPreviousPage);
 
-    // Play a bouncy animation if there's no incoming page
-    if (!hasLeftPage) {
+    // Play a bouncy animation if there's no incoming page and the animator
+    // doesn't have runway (which indicates a page exists despite stale flags).
+    if (!hasLeftPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeLeft]) {
         if (!animated) { return; }
         [self _playBounceAnimationInDirection:TOPagingViewDirectionRightToLeft];
         return;
@@ -597,8 +598,9 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
                                 (!isDirectionReversed && _hasNextPage);
 
-    // Play a bouncy animation if there's no incoming page
-    if (!hasRightPage) {
+    // Play a bouncy animation if there's no incoming page and the animator
+    // doesn't have runway (which indicates a page exists despite stale flags).
+    if (!hasRightPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeRight]) {
         if (!animated) { return; }
         [self _playBounceAnimationInDirection:TOPagingViewDirectionLeftToRight];
         return;
@@ -870,13 +872,6 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
                                         && TOPagingViewIsInitialPageForPageView(self, _currentPageView);
     const BOOL isPreviousPage = !isDetectingDirection && ((!isDirectionReversed && isLeftDirection) ||
                                                           (isDirectionReversed && !isLeftDirection));
-
-    // If we're already animating toward the last available page, don't extend the animation
-    if (_pageAnimator.isAnimating) {
-        if ((isPreviousPage && !_hasPreviousPage) || (!isPreviousPage && !_hasNextPage)) {
-            return;
-        }
-    }
 
     // Fire the willTurn delegate for each requested animated turn.
     const TOPagingViewPageType type = (isPreviousPage ? TOPagingViewPageTypePrevious : TOPagingViewPageTypeNext);

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -24,7 +24,7 @@
 #import "TOPagingViewAnimator.h"
 #import <objc/runtime.h>
 
-/// Mark methods as being statically called to increase performance
+/// Mark implementation-only methods as being statically called to increase performance.
 #define TOPAGINGVIEW_OBJC_DIRECT __attribute__((objc_direct))
 
 // -----------------------------------------------------------------
@@ -35,7 +35,7 @@ static NSString *const kTOPagingViewDefaultIdentifier = @"TOPagingView.DefaultPa
 /// There are always 3 slots, with content insetting used to block pages on either side.
 static const CGFloat kTOPagingViewPageSlotCount = 3.0f;
 
-/// The amount of padding along the edge of the screen shown when the "no incoming page" animation plays
+/// The amount of padding along the edge of the screen shown when the "no incoming page" animation plays.
 static const CGFloat kTOPagingViewBumperWidthCompact = 48.0f;
 static const CGFloat kTOPagingViewBumperWidthRegular = 96.0f;
 
@@ -44,7 +44,7 @@ static const NSInteger kTOPagingViewAnimationOptions = (UIViewAnimationOptionAll
 
 // -----------------------------------------------------------------
 
-/// A struct to cache which methods the current delegate implements. */
+/// A struct to cache which methods the current delegate implements.
 typedef struct {
     unsigned int delegateWillTurnToPage:1;
     unsigned int delegateDidTurnToPage:1;
@@ -75,7 +75,8 @@ typedef struct {
 
 /// A lightweight proxy that intercepts UIScrollViewDelegate calls.
 /// Uses NSProxy message forwarding to automatically forward all delegate methods
-/// to the external delegate, while intercepting scrollViewDidScroll: for internal use.
+/// to the external delegate, while intercepting scrollViewDidScroll: and
+/// scrollViewWillBeginDragging: for internal use.
 /// This approach avoids manually implementing every UIScrollViewDelegate method.
 @interface TOScrollViewDelegateProxy : NSProxy <UIScrollViewDelegate>
 @property (nonatomic, weak) TOPagingView *pagingView;
@@ -104,6 +105,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 // -----------------------------------------------------------------
 
 @interface TOPagingView ()
+
+- (void)layoutContent TOPAGINGVIEW_OBJC_DIRECT;
 
 /// The scroll view managed by this container.
 @property (nonatomic, strong, readwrite) UIScrollView *scrollView;
@@ -140,14 +143,14 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 @property (nonatomic, assign) CGFloat draggingOrigin;
 @property (nonatomic, assign) TOPagingViewPageType draggingDirectionType;
 
-/// State tracking for handling offloading view configuration to another run-loop tick
+/// State tracking for offloading view configuration to another run-loop tick.
 @property (nonatomic, assign) BOOL needsNextPage;
 @property (nonatomic, assign) BOOL needsPreviousPage;
 
-/// The animator used to play smooth transitions when turning pages
+/// The animator used to play smooth transitions when turning pages.
 @property (nonatomic, strong) TOPagingViewAnimator *pageAnimator;
 
-/// The delegate proxy that handles scroll view delegate calls
+/// The delegate proxy that handles scroll view delegate calls.
 @property (nonatomic, strong) TOScrollViewDelegateProxy *scrollViewDelegateProxy;
 
 @end
@@ -244,7 +247,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 
 #pragma mark - View Lifecycle -
 
-- (void)setFrame:(CGRect)frame {
+- (void)setFrame:(CGRect)frame
+{
     const CGRect oldFrame = self.frame;
     [super setFrame:frame];
     if (!CGRectEqualToRect(frame, oldFrame)) {
@@ -252,7 +256,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     }
 }
 
-- (void)layoutSubviews {
+- (void)layoutSubviews
+{
     [super layoutSubviews];
     [self layoutContent];
 }
@@ -309,7 +314,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     [self reload];
 }
 
-- (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer {
+- (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
     if ([gestureRecognizer isKindOfClass:UITapGestureRecognizer.class]) {
         [_scrollView.panGestureRecognizer requireGestureRecognizerToFail:gestureRecognizer];
     }
@@ -369,7 +375,7 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     // Cache the protocol methods this class implements to save checking each time
     TOPagingViewCachedProtocolFlagsForPageViewClass(self, pageViewClass);
 
-    // Fetch the page identifier (or use the default if none were 
+    // Fetch the page identifier (or use the default if none were provided).
     const NSString *pageIdentifier = TOPagingViewIdentifierForPageViewClass(self, pageViewClass);
     
     // Lazily make the store for the first time
@@ -580,8 +586,8 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) ||
                              (!isDirectionReversed && _hasPreviousPage);
 
-    // Play a bouncy animation if there's no incoming page and the animator
-    // doesn't have runway (which indicates a page exists despite stale flags).
+    // Play a bouncy animation if there's no page available on that side and
+    // the scroll view isn't already settling from a user-driven swipe.
     if (!hasLeftPage && !_scrollView.isDecelerating) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
@@ -598,8 +604,8 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
                                 (!isDirectionReversed && _hasNextPage);
 
-    // Play a bouncy animation if there's no incoming page and the animator
-    // doesn't have runway (which indicates a page exists despite stale flags).
+    // Play a bouncy animation if there's no page available on that side and
+    // the scroll view isn't already settling from a user-driven swipe.
     if (!hasRightPage && !_scrollView.isDecelerating) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
@@ -753,11 +759,10 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
     const CGFloat offsetX = offset.x;
 
     // By default, we only perform transitions when a new page has fully landed on screen.
-    // This is so by default, potentially heavy layout operations are deferred until there's no motion on screen.
-    
-    // When the page animator is active, we need to transition sooner than the far edge.
-    // Treat the center slot as the "arming" point, and only fire when we first cross away
-    // from it so we don't repeatedly transition while remaining on the same side.
+    // This defers heavier layout work until there is no visible motion.
+    //
+    // When the page animator is active, transition as soon as movement commits away from
+    // the middle slot so the internal page bookkeeping stays ahead of rapid animation.
     const CGFloat rightHandThreshold = isAnimatingRight ? segmentWidth + 1.0f : contentSize.width - segmentWidth;
     const CGFloat leftHandThreshold = isAnimatingLeft ? segmentWidth - 1.0f : FLT_EPSILON;
 
@@ -821,7 +826,7 @@ static inline void TOPagingViewUpdateEnabledPages(TOPagingView *view)
     const CGFloat segmentWidth = TOPagingViewScrollViewPageWidth(view);
     const BOOL isReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
 
-    // Check the offset and disable the adjancent slot if we've gone over the threshold
+    // Check the offset and disable the adjacent slot if we've gone over the threshold.
     BOOL isEnabled = NO;
     UIRectEdge edge = UIRectEdgeNone;
     if (offset.x < segmentWidth) { // Check the left page slot
@@ -832,7 +837,7 @@ static inline void TOPagingViewUpdateEnabledPages(TOPagingView *view)
         edge = UIRectEdgeRight;
     }
 
-    // If we matched and edge, update its state
+    // If we matched an edge, update its state.
     if (edge != UIRectEdgeNone) {
         TOPagingViewSetPageSlotEnabled(view, isEnabled, edge);
     }
@@ -852,9 +857,8 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     if (enabled && inset == segmentWidth) { return; }
     else if (!enabled && inset == -segmentWidth) { return; }
 
-    // When the slot is enabled, expand the scrollable region an
-    // extra slot, so that it won't bump against the edge of the
-    // scroll region when scrolling rapidly.
+    // When the slot is enabled, expand the scrollable region by an extra slot
+    // so it won't bump against the edge of the scroll region when scrolling rapidly.
     // Otherwise, inset it a whole slot to disable it completely.
     CGFloat value = enabled ? segmentWidth : -segmentWidth;
 
@@ -1121,12 +1125,12 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     view->_currentPageView.frame = TOPagingViewCurrentPageFrame(view);
     view->_previousPageView.frame = TOPagingViewPreviousPageFrame(view);
 
-    // Inform the delegate we have comitted to a transition so we can update state for the next page
+    // Inform the delegate we have committed to a transition so we can update state for the next page.
     if (view->_delegateFlags.delegateDidTurnToPage) {
         [view->_delegate pagingView:view didTurnToPageOfType:TOPagingViewPageTypeNext];
     }
 
-    // Offload the heavy work to a new run-loop cyle so we don't overload the current one
+    // Offload the heavy work to a new run-loop cycle so we don't overload the current one.
     view->_needsNextPage = YES;
     [view setNeedsLayout];
 
@@ -1178,7 +1182,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         [view->_delegate pagingView:view didTurnToPageOfType:TOPagingViewPageTypePrevious];
     }
 
-    // Offload the heavy work to a new run-loop cyle so we don't overload the current one
+    // Offload the heavy work to a new run-loop cycle so we don't overload the current one.
     view->_needsPreviousPage = YES;
     [view setNeedsLayout];
 
@@ -1202,7 +1206,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
 
 - (void)_fetchNewNextPage TOPAGINGVIEW_OBJC_DIRECT
 {
-    // Query the data source for the next page
+    // Query the data source for a replacement next page.
     UIView<TOPagingViewPage> *nextPage = [_dataSource pagingView:self
                                                  pageViewForType:TOPagingViewPageTypeNext
                                                  currentPageView:_nextPageView];
@@ -1219,14 +1223,13 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         [_pageAnimator clampAnimationToCurrentOffsetInDirection:direction];
     }
 
-    // If the next page ended up being nil,
-    // set a flag to prevent churning, and inset the scroll inset
+    // If the next page ended up being nil, set a flag to prevent churning.
     _hasNextPage = (nextPage != nil);
 }
 
 - (void)_fetchNewPreviousPage TOPAGINGVIEW_OBJC_DIRECT
 {
-    // Query the data source for the previous page, and exit out if there is no more page data
+    // Query the data source for a replacement previous page.
     UIView<TOPagingViewPage> *previousPage = [_dataSource pagingView:self
                                                      pageViewForType:TOPagingViewPageTypePrevious
                                                      currentPageView:_previousPageView];
@@ -1464,7 +1467,8 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     [self _rearrangePagesForScrollDirection:_pageScrollDirection];
 }
 
-- (void)setIsDynamicPageDirectionEnabled:(BOOL)isDynamicPageDirectionEnabled {
+- (void)setIsDynamicPageDirectionEnabled:(BOOL)isDynamicPageDirectionEnabled
+{
     if (_isDynamicPageDirectionEnabled == isDynamicPageDirectionEnabled) { return; }
     _isDynamicPageDirectionEnabled = isDynamicPageDirectionEnabled;
     [self reload];
@@ -1499,16 +1503,16 @@ static inline CGRect TOPagingViewCurrentPageFrame(TOPagingView *view)
 
 static inline CGRect TOPagingViewNextPageFrame(TOPagingView *view)
 {
-    // Next frame is on the right side when non-reversed,
-    // and on the right side when reversed
+    // The next frame is on the right side when non-reversed,
+    // and on the left side when reversed.
     return TOPagingViewIsDirectionReversed(view) ?
             TOPagingViewLeftPageFrame(view) : TOPagingViewRightPageFrame(view);
 }
 
 static inline CGRect TOPagingViewPreviousPageFrame(TOPagingView *view)
 {
-    // Previous frame is on the left side when non-reversed,
-    // and on the right side when reversed
+    // The previous frame is on the left side when non-reversed,
+    // and on the right side when reversed.
     return TOPagingViewIsDirectionReversed(view) ?
             TOPagingViewRightPageFrame(view) : TOPagingViewLeftPageFrame(view);
 }

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -83,6 +83,10 @@ typedef struct {
 - (instancetype)init;
 @end
 
+@interface TOPagingViewAnimator (Internal)
+- (void)didTransition;
+@end
+
 // -----------------------------------------------------------------
 // Convenience functions for easier mapping Objective-C and C constructs
 
@@ -899,7 +903,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     };
 
     // Animate the page turn via CADisplayLink using logical distance and per-frame deltas.
-    _pageAnimator.pageWidth = _scrollView.frame.size.width;
+    _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
     [_pageAnimator turnToPageInDirection:direction];
 }
 
@@ -1117,6 +1121,7 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     if (isDirectionReversed) { contentOffset.x += scrollViewPageWidth; }
     else { contentOffset.x -= scrollViewPageWidth; }
     view->_scrollView.contentOffset = contentOffset;
+    [view->_pageAnimator didTransition];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1167,6 +1172,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     if (isDirectionReversed) { contentOffset.x -= TOPagingViewScrollViewPageWidth(view); }
     else { contentOffset.x += scrollViewPageWidth; }
     view->_scrollView.contentOffset = contentOffset;
+    [view->_pageAnimator didTransition];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -76,7 +76,7 @@ typedef struct {
 /// A lightweight proxy that intercepts UIScrollViewDelegate calls.
 /// Uses NSProxy message forwarding to automatically forward all delegate methods
 /// to the external delegate, while intercepting scrollViewDidScroll: and
-/// scrollViewWillBeginDragging: for internal use.
+/// scrollViewWillBeginDragging: for internal state tracking.
 /// This approach avoids manually implementing every UIScrollViewDelegate method.
 @interface TOScrollViewDelegateProxy : NSProxy <UIScrollViewDelegate>
 @property (nonatomic, weak) TOPagingView *pagingView;
@@ -107,6 +107,10 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 @interface TOPagingView ()
 
 - (void)layoutContent TOPAGINGVIEW_OBJC_DIRECT;
+- (void)_scrollViewDidScroll TOPAGINGVIEW_OBJC_DIRECT;
+- (void)_scrollViewWillBeginDragging TOPAGINGVIEW_OBJC_DIRECT;
+- (BOOL)_scrollViewIsDeceleratingInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT;
+- (void)_resetScrollDecelerationTracking TOPAGINGVIEW_OBJC_DIRECT;
 
 /// The scroll view managed by this container.
 @property (nonatomic, strong, readwrite) UIScrollView *scrollView;
@@ -142,6 +146,10 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 /// State tracking for when a user is dragging their finger on screen.
 @property (nonatomic, assign) CGFloat draggingOrigin;
 @property (nonatomic, assign) TOPagingViewPageType draggingDirectionType;
+
+/// State tracking for when the wrapped scroll view is decelerating.
+@property (nonatomic, assign) CGFloat scrollDecelerationOrigin;
+@property (nonatomic, assign, readwrite) UIRectEdge scrollDecelerationDirection;
 
 /// State tracking for offloading view configuration to another run-loop tick.
 @property (nonatomic, assign) BOOL needsNextPage;
@@ -190,6 +198,8 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     _pageViewProtocolFlags = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsOpaquePersonality
                                                    valueOptions:NSPointerFunctionsStrongMemory];
     memset(&_delegateFlags, 0, sizeof(TOPagingViewDelegateFlags));
+    _draggingOrigin = -CGFLOAT_MAX;
+    _scrollDecelerationOrigin = -CGFLOAT_MAX;
 
     // Configure the main properties of this view
     self.clipsToBounds = YES; // The scroll view intentionally overlaps, so this view MUST clip.
@@ -357,12 +367,24 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     if (_pageAnimator.isAnimating) {
         [_pageAnimator stopAnimation];
     }
+    [self _resetScrollDecelerationTracking];
 }
 
 - (void)_layoutPages TOPAGINGVIEW_OBJC_DIRECT
 {
     // Proxy through to the scroll handler for layout updates
     [self _scrollViewDidScroll];
+}
+
+- (BOOL)_scrollViewIsDeceleratingInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT
+{
+    return _scrollView.isDecelerating && _scrollDecelerationDirection == direction;
+}
+
+- (void)_resetScrollDecelerationTracking TOPAGINGVIEW_OBJC_DIRECT
+{
+    _scrollDecelerationOrigin = -CGFLOAT_MAX;
+    _scrollDecelerationDirection = UIRectEdgeNone;
 }
 
 #pragma mark - Page Setup -
@@ -588,7 +610,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasLeftPage && !_scrollView.isDecelerating) {
+    if (!hasLeftPage && ![self _scrollViewIsDeceleratingInDirection:UIRectEdgeRight]) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
@@ -606,7 +628,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasRightPage && !_scrollView.isDecelerating) {
+    if (!hasRightPage && ![self _scrollViewIsDeceleratingInDirection:UIRectEdgeLeft]) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
@@ -649,6 +671,9 @@ static inline void TOPagingViewLayoutPages(TOPagingView *view) {
         && TOPagingViewIsInitialPageForPageView(view, view->_currentPageView)) {
         TOPagingViewHandleDynamicPageDirectionLayout(view);
     }
+
+    // Track deceleration direction before page transitions potentially recenter the scroll view.
+    TOPagingViewUpdateDecelerationInteractions(view);
 
     // Check the offset of the scroll view, and when it passes over
     // the mid point between two pages, perform the page transition
@@ -773,6 +798,36 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
         // Check if we're over the left threshold
         TOPagingViewTransitionOverToPreviousPage(view);
     }
+}
+
+static inline UIRectEdge TOPagingViewDirectionForOffsetDelta(CGFloat offset, CGFloat origin)
+{
+    if (offset < origin - FLT_EPSILON) { return UIRectEdgeLeft; }
+    if (offset > origin + FLT_EPSILON) { return UIRectEdgeRight; }
+    return UIRectEdgeNone;
+}
+
+static inline void TOPagingViewUpdateDecelerationInteractions(TOPagingView *view)
+{
+    if (!view->_scrollView.isDecelerating) {
+        if (view->_scrollDecelerationDirection != UIRectEdgeNone ||
+            view->_scrollDecelerationOrigin > -CGFLOAT_MAX) {
+            [view _resetScrollDecelerationTracking];
+        }
+        return;
+    }
+
+    const CGFloat offset = view->_scrollView.contentOffset.x;
+    if (view->_scrollDecelerationOrigin <= -CGFLOAT_MAX + FLT_EPSILON) {
+        view->_scrollDecelerationOrigin = offset;
+        return;
+    }
+
+    const UIRectEdge direction = TOPagingViewDirectionForOffsetDelta(offset, view->_scrollDecelerationOrigin);
+    if (direction != UIRectEdgeNone) {
+        view->_scrollDecelerationDirection = direction;
+    }
+    view->_scrollDecelerationOrigin = offset;
 }
 
 static inline void TOPagingViewUpdateDragInteractions(TOPagingView *view)
@@ -909,6 +964,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     // If the scroll view is decelerating from a swipe, cancel it.
     if (scrollView.isDecelerating) {
         [scrollView setContentOffset:scrollView.contentOffset animated:NO];
+        [self _resetScrollDecelerationTracking];
     }
 
     // Set up the completion handler to notify the external scroll view delegate
@@ -939,6 +995,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     // If the scroll view is decelerating from a swipe, cancel it.
     if (_scrollView.isDecelerating) {
         [_scrollView setContentOffset:_scrollView.contentOffset animated:NO];
+        [self _resetScrollDecelerationTracking];
     }
 
     // Reclaim the next and previous pages since these will always need to be regenerated
@@ -1148,6 +1205,9 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     if (view->_scrollView.isDragging) {
         view->_draggingOrigin = -CGFLOAT_MAX;
     }
+    if (view->_scrollView.isDecelerating) {
+        view->_scrollDecelerationOrigin = -CGFLOAT_MAX;
+    }
 
     view->_disableLayout = NO;
 }
@@ -1199,6 +1259,9 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
         view->_draggingOrigin = -CGFLOAT_MAX;
+    }
+    if (view->_scrollView.isDecelerating) {
+        view->_scrollDecelerationOrigin = -CGFLOAT_MAX;
     }
 
     view->_disableLayout = NO;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -85,6 +85,7 @@ typedef struct {
 
 @interface TOPagingViewAnimator (Internal)
 - (void)didTransitionWithOffset:(CGFloat)offset;
+- (void)clampAnimationToCurrentOffsetInDirection:(UIRectEdge)direction;
 @end
 
 // -----------------------------------------------------------------
@@ -586,7 +587,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no incoming page and the animator
     // doesn't have runway (which indicates a page exists despite stale flags).
-    if (!hasLeftPage) {
+    if (!hasLeftPage && !_scrollView.isDecelerating) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
@@ -604,7 +605,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no incoming page and the animator
     // doesn't have runway (which indicates a page exists despite stale flags).
-    if (!hasRightPage) {
+    if (!hasRightPage && !_scrollView.isDecelerating) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
@@ -763,7 +764,6 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
     const CGFloat leftHandThreshold = isAnimating ? segmentWidth - 1.0f : FLT_EPSILON;
 
     // Check if we went over the right-hand threshold to start transitioning the pages
-    NSLog(@"offset: %f", offsetX);
     if ((!isReversed && offsetX >= rightHandThreshold) || (isReversed && offsetX <= leftHandThreshold)) {
         TOPagingViewTransitionOverToNextPage(view);
     } else if ((isReversed && offsetX >= rightHandThreshold) || (!isReversed && offsetX <= leftHandThreshold)) {
@@ -920,7 +920,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Animate the page turn via CADisplayLink using logical offsets relative to the center slot.
+    // Animate the page turn via CADisplayLink by directly driving the scroll view content offset.
     _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
     [_pageAnimator turnToPageInDirection:direction];
 }
@@ -1214,6 +1214,11 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, nextPage);
         _nextPageView = nextPage;
         _nextPageView.frame = TOPagingViewNextPageFrame(self);
+    } else {
+        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight
+                                        ? UIRectEdgeRight
+                                        : UIRectEdgeLeft;
+        [_pageAnimator clampAnimationToCurrentOffsetInDirection:direction];
     }
 
     // If the next page ended up being nil,
@@ -1233,6 +1238,11 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, previousPage);
         _previousPageView = previousPage;
         _previousPageView.frame = TOPagingViewPreviousPageFrame(self);
+    } else {
+        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight
+                                        ? UIRectEdgeLeft
+                                        : UIRectEdgeRight;
+        [_pageAnimator clampAnimationToCurrentOffsetInDirection:direction];
     }
 
     // If the previous page ended up being nil, set a flag so we don't check again until we need to

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -899,7 +899,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     };
 
     // Animate the page turn via CADisplayLink using logical distance and per-frame deltas.
-    _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
+    _pageAnimator.pageWidth = _scrollView.frame.size.width;
     [_pageAnimator turnToPageInDirection:direction];
 }
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1210,6 +1210,11 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, nextPage);
         _nextPageView = nextPage;
         _nextPageView.frame = TOPagingViewNextPageFrame(self);
+    } else {
+        // If we're about to continue scrolling in that direction, short circuit the animator.
+        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
+                                        UIRectEdgeRight : UIRectEdgeLeft;
+        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the next page ended up being nil,
@@ -1229,6 +1234,11 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, previousPage);
         _previousPageView = previousPage;
         _previousPageView.frame = TOPagingViewPreviousPageFrame(self);
+    } else {
+        // If we're about to continue scrolling in that direction, short circuit the animator.
+        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
+                                        UIRectEdgeLeft : UIRectEdgeRight;
+        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the previous page ended up being nil, set a flag so we don't check again until we need to

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1118,9 +1118,10 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     CGPoint contentOffset = view->_scrollView.contentOffset;
     const CGFloat scrollViewPageWidth = TOPagingViewScrollViewPageWidth(view);
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
-    if (isDirectionReversed) { contentOffset.x += scrollViewPageWidth; }
-    else { contentOffset.x -= scrollViewPageWidth; }
+    const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? 1.0f : -1.0f);
+    contentOffset.x += offset;
     view->_scrollView.contentOffset = contentOffset;
+    [view->_pageAnimator didTransitionWithOffset:offset];
 
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
@@ -1168,10 +1169,11 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     CGPoint contentOffset = view->_scrollView.contentOffset;
     const CGFloat scrollViewPageWidth = TOPagingViewScrollViewPageWidth(view);
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
-    if (isDirectionReversed) { contentOffset.x -= TOPagingViewScrollViewPageWidth(view); }
-    else { contentOffset.x += scrollViewPageWidth; }
+    const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? -1.0f : 1.0f);
+    contentOffset.x += offset;
     view->_scrollView.contentOffset = contentOffset;
-
+    [view->_pageAnimator didTransitionWithOffset:offset];
+    
     // If we're dragging, reset the state
     if (view->_scrollView.isDragging) {
         view->_draggingOrigin = -CGFLOAT_MAX;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -262,7 +262,7 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     [self layoutContent];
 }
 
-- (void)layoutContent
+- (void)layoutContent TOPAGINGVIEW_OBJC_DIRECT
 {
     // If need be, request new next/previous pages
     [self _requestPendingPages];
@@ -602,7 +602,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 {
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
-                                (!isDirectionReversed && _hasNextPage);
+                              (!isDirectionReversed && _hasNextPage);
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
@@ -800,7 +800,7 @@ static inline void TOPagingViewUpdateDragInteractions(TOPagingView *view)
     const BOOL isReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     TOPagingViewPageType directionType;
 
-    //If we're detecting the direction, it will be 'next' regardless
+    // If we're detecting the direction, it will be 'next' regardless.
     if (isDetectingDirection) {
         directionType = TOPagingViewPageTypeNext;
     } else if (offset < view->_draggingOrigin - FLT_EPSILON) { // We dragged to the right
@@ -1177,7 +1177,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     view->_currentPageView.frame = TOPagingViewCurrentPageFrame(view);
     view->_nextPageView.frame = TOPagingViewNextPageFrame(view);
 
-    // Inform the delegate we have just committed to a transition so we can update state for the previous page
+    // Inform the delegate we have just committed to a transition so we can update state for the previous page.
     if (view->_delegateFlags.delegateDidTurnToPage) {
         [view->_delegate pagingView:view didTurnToPageOfType:TOPagingViewPageTypePrevious];
     }
@@ -1246,7 +1246,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         [_pageAnimator clampAnimationToCurrentOffsetInDirection:direction];
     }
 
-    // If the previous page ended up being nil, set a flag so we don't check again until we need to
+    // If the previous page ended up being nil, set a flag so we don't check again until we need to.
     _hasPreviousPage = (previousPage != nil);
 }
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -340,6 +340,10 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
 /// This replaces the KVO observer for better performance.
 - (void)_scrollViewDidScroll TOPAGINGVIEW_OBJC_DIRECT
 {
+    if (_scrollView.contentOffset.x == 1173) {
+        NSLog(@"We");
+    }
+    
     if (!_disableLayout) {
         TOPagingViewLayoutPages(self);
     }
@@ -1135,9 +1139,6 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view)
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? 1.0f : -1.0f);
     contentOffset.x += offset;
-    if (view->_pageAnimator.isAnimating) {
-        contentOffset.x = scrollViewPageWidth;
-    }
     view->_scrollView.contentOffset = contentOffset;
     [view->_pageAnimator didTransitionWithOffset:(contentOffset.x - previousOffsetX)];
 
@@ -1190,9 +1191,6 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     const BOOL isDirectionReversed = (view->_pageScrollDirection == TOPagingViewDirectionRightToLeft);
     const CGFloat offset = scrollViewPageWidth * (isDirectionReversed ? -1.0f : 1.0f);
     contentOffset.x += offset;
-    if (view->_pageAnimator.isAnimating) {
-        contentOffset.x = scrollViewPageWidth;
-    }
     view->_scrollView.contentOffset = contentOffset;
     [view->_pageAnimator didTransitionWithOffset:(contentOffset.x - previousOffsetX)];
     
@@ -1553,6 +1551,11 @@ static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
+//    NSLog(@"----");
+//    NSLog(@"scroll %f", scrollView.contentOffset.x);
+//    NSLog(@"%@", NSThread.callStackSymbols);
+//    NSLog(@"----");
+    
     // Notify the paging view of scroll changes
     [_pagingView _scrollViewDidScroll];
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1529,7 +1529,7 @@ static inline CGRect TOPagingViewRightPageFrame(TOPagingView *view)
 
 #pragma mark - Scroll View Delegate Proxy Implementation -
 
-/// The one selector we intercept to notify the paging view of scroll events.
+/// The delegate selectors we intercept to notify the paging view of scroll events.
 static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
     return sel == @selector(scrollViewDidScroll:)
         || sel == @selector(scrollViewWillBeginDragging:);

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -582,8 +582,8 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no incoming page and the animator
     // doesn't have runway (which indicates a page exists despite stale flags).
-    if (!hasLeftPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeLeft]) {
-        if (!animated) { return; }
+    if (!hasLeftPage) {
+        if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
     }
@@ -600,8 +600,8 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // Play a bouncy animation if there's no incoming page and the animator
     // doesn't have runway (which indicates a page exists despite stale flags).
-    if (!hasRightPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeRight]) {
-        if (!animated) { return; }
+    if (!hasRightPage) {
+        if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
     }
@@ -746,13 +746,24 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view)
     const CGPoint offset = view->_scrollView.contentOffset;
     const CGFloat segmentWidth = TOPagingViewScrollViewPageWidth(view);
     const CGSize contentSize = view->_scrollView.contentSize;
+    const BOOL isAnimating = view->_pageAnimator.isAnimating;
+    const CGFloat offsetX = offset.x;
+
+    // By default, we only perform transitions when a new page has fully landed on screen.
+    // This is so by default, potentially heavy layout operations are deferred until there's no motion on screen.
+    
+    // When the page animator is active, we need to transition sooner than the far edge.
+    // Treat the center slot as the "arming" point, and only fire when we first cross away
+    // from it so we don't repeatedly transition while remaining on the same side.
+    const CGFloat rightHandThreshold = isAnimating ? segmentWidth + 1.0f : contentSize.width - segmentWidth;
+    const CGFloat leftHandThreshold = isAnimating ? segmentWidth - 1.0f : FLT_EPSILON;
 
     // Check if we went over the right-hand threshold to start transitioning the pages
-    if ((!isReversed && offset.x >= (contentSize.width - segmentWidth))
-        || (isReversed && offset.x <= FLT_EPSILON)) {
+    NSLog(@"offset: %f", offsetX);
+    if ((!isReversed && offsetX >= rightHandThreshold) || (isReversed && offsetX <= leftHandThreshold)) {
         TOPagingViewTransitionOverToNextPage(view);
-    } else if ((isReversed && offset.x >= (contentSize.width - segmentWidth))
-               || (!isReversed && offset.x <= FLT_EPSILON)) { // Check if we're over the left threshold
+    } else if ((isReversed && offsetX >= rightHandThreshold) || (!isReversed && offsetX <= leftHandThreshold)) {
+        // Check if we're over the left threshold
         TOPagingViewTransitionOverToPreviousPage(view);
     }
 }
@@ -1205,11 +1216,6 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, nextPage);
         _nextPageView = nextPage;
         _nextPageView.frame = TOPagingViewNextPageFrame(self);
-    } else {
-        // If we're about to continue scrolling in that direction, short circuit the animator.
-        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
-                                        UIRectEdgeRight : UIRectEdgeLeft;
-        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the next page ended up being nil,
@@ -1229,11 +1235,6 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         TOPagingViewInsertPageView(self, previousPage);
         _previousPageView = previousPage;
         _previousPageView.frame = TOPagingViewPreviousPageFrame(self);
-    } else {
-        // If we're about to continue scrolling in that direction, short circuit the animator.
-        const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
-                                        UIRectEdgeLeft : UIRectEdgeRight;
-        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the previous page ended up being nil, set a flag so we don't check again until we need to

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -345,6 +345,14 @@ static inline Class TOPagingViewClassForValue(NSValue *value) {
     }
 }
 
+/// Called by the scroll view delegate proxy when the user begins dragging.
+- (void)_scrollViewWillBeginDragging TOPAGINGVIEW_OBJC_DIRECT
+{
+    if (_pageAnimator.isAnimating) {
+        [_pageAnimator stopAnimation];
+    }
+}
+
 - (void)_layoutPages TOPAGINGVIEW_OBJC_DIRECT
 {
     // Proxy through to the scroll handler for layout updates
@@ -1523,7 +1531,8 @@ static inline CGRect TOPagingViewRightPageFrame(TOPagingView *view)
 
 /// The one selector we intercept to notify the paging view of scroll events.
 static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
-    return sel == @selector(scrollViewDidScroll:);
+    return sel == @selector(scrollViewDidScroll:)
+        || sel == @selector(scrollViewWillBeginDragging:);
 }
 
 @implementation TOScrollViewDelegateProxy
@@ -1544,6 +1553,17 @@ static inline BOOL TOScrollViewDelegateProxyIsInterceptedSelector(SEL sel) {
     // Forward to external delegate
     if ([_externalDelegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
         [_externalDelegate scrollViewDidScroll:scrollView];
+    }
+}
+
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
+{
+    // Stop any programmatic turn so the user's gesture takes over immediately.
+    [_pagingView _scrollViewWillBeginDragging];
+
+    // Forward to external delegate
+    if ([_externalDelegate respondsToSelector:@selector(scrollViewWillBeginDragging:)]) {
+        [_externalDelegate scrollViewWillBeginDragging:scrollView];
     }
 }
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -609,13 +609,14 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 {
     const CGFloat offsetX = _scrollView.contentOffset.x;
     const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
+    const CGFloat lastSegment = _scrollView.contentSize.width - pageWidth;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
                               (!isDirectionReversed && _hasNextPage);
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasRightPage && offsetX >= pageWidth - FLT_EPSILON) {
+    if (!hasRightPage && offsetX + pageWidth >= lastSegment - FLT_EPSILON) {
         if (!animated || _pageAnimator.isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -587,16 +587,18 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (void)turnToLeftPageAnimated:(BOOL)animated
 {
-    const CGFloat offsetX = _scrollView.contentOffset.x;
+    const CGFloat offset = _scrollView.contentOffset.x;
     const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
+    const BOOL isAnimating = _pageAnimator.isAnimating;
+    const BOOL isAnimatingLeft = isAnimating && _pageAnimator.direction == UIRectEdgeLeft;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) ||
                              (!isDirectionReversed && _hasPreviousPage);
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasLeftPage && offsetX < pageWidth) {
-        if (!animated || _pageAnimator.isAnimating) { return; }
+    if (!hasLeftPage&& (offset <= pageWidth + FLT_EPSILON || isAnimatingLeft)) {
+        if (!animated || isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
     }
@@ -607,17 +609,18 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (void)turnToRightPageAnimated:(BOOL)animated
 {
-    const CGFloat offsetX = _scrollView.contentOffset.x;
+    const CGFloat offset = _scrollView.contentOffset.x;
     const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
-    const CGFloat lastSegment = _scrollView.contentSize.width - pageWidth;
+    const BOOL isAnimating = _pageAnimator.isAnimating;
+    const BOOL isAnimatingRight = isAnimating && _pageAnimator.direction == UIRectEdgeRight;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(self);
     const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) ||
                               (!isDirectionReversed && _hasNextPage);
 
-    // Play a bouncy animation if there's no page available on that side and
-    // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasRightPage && offsetX + pageWidth >= lastSegment - FLT_EPSILON) {
-        if (!animated || _pageAnimator.isAnimating) { return; }
+    // If we're partially at the last page and animating in, skip turning again to let it bottom out.
+    // Otherwise, we've hit the edge, so play a 'bounce' visual cue to make it clear there's no more pages.
+    if (!hasRightPage && (offset >= pageWidth - FLT_EPSILON || isAnimatingRight)) {
+        if (!animated || isAnimating) { return; }
         [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
     }

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1209,9 +1209,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         // If we're about to continue scrolling in that direction, short circuit the animator.
         const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
                                         UIRectEdgeRight : UIRectEdgeLeft;
-        if ([_pageAnimator stopAnimationInDirection:direction]) {
-            [self _playBounceAnimationInDirection:direction];
-        }
+        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the next page ended up being nil,
@@ -1235,9 +1233,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         // If we're about to continue scrolling in that direction, short circuit the animator.
         const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
                                         UIRectEdgeLeft : UIRectEdgeRight;
-        if ([_pageAnimator stopAnimationInDirection:direction]) {
-            [self _playBounceAnimationInDirection:direction];
-        }
+        [_pageAnimator stopAnimationInDirection:direction];
     }
 
     // If the previous page ended up being nil, set a flag so we don't check again until we need to

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -584,7 +584,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     // doesn't have runway (which indicates a page exists despite stale flags).
     if (!hasLeftPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeLeft]) {
         if (!animated) { return; }
-        [self _playBounceAnimationInDirection:TOPagingViewDirectionRightToLeft];
+        [self _playBounceAnimationInDirection:UIRectEdgeLeft];
         return;
     }
 
@@ -602,7 +602,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     // doesn't have runway (which indicates a page exists despite stale flags).
     if (!hasRightPage && ![_pageAnimator hasRunwayInDirection:UIRectEdgeRight]) {
         if (!animated) { return; }
-        [self _playBounceAnimationInDirection:TOPagingViewDirectionLeftToRight];
+        [self _playBounceAnimationInDirection:UIRectEdgeRight];
         return;
     }
 
@@ -1209,7 +1209,9 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         // If we're about to continue scrolling in that direction, short circuit the animator.
         const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
                                         UIRectEdgeRight : UIRectEdgeLeft;
-        [_pageAnimator stopAnimationInDirection:direction];
+        if ([_pageAnimator stopAnimationInDirection:direction]) {
+            [self _playBounceAnimationInDirection:direction];
+        }
     }
 
     // If the next page ended up being nil,
@@ -1233,7 +1235,9 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
         // If we're about to continue scrolling in that direction, short circuit the animator.
         const UIRectEdge direction = _pageScrollDirection == TOPagingViewDirectionLeftToRight ?
                                         UIRectEdgeLeft : UIRectEdgeRight;
-        [_pageAnimator stopAnimationInDirection:direction];
+        if ([_pageAnimator stopAnimationInDirection:direction]) {
+            [self _playBounceAnimationInDirection:direction];
+        }
     }
 
     // If the previous page ended up being nil, set a flag so we don't check again until we need to
@@ -1281,9 +1285,9 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view)
     _disableLayout = NO;
 }
 
-- (void)_playBounceAnimationInDirection:(TOPagingViewDirection)direction TOPAGINGVIEW_OBJC_DIRECT
+- (void)_playBounceAnimationInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT
 {
-    const CGFloat offsetModifier = (direction == TOPagingViewDirectionLeftToRight) ? 1.0f : -1.0f;
+    const CGFloat offsetModifier = (direction == UIRectEdgeLeft) ? -1.0f : 1.0f;
     const BOOL isCompactSizeClass = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
     const CGFloat bumperPadding = (isCompactSizeClass ? kTOPagingViewBumperWidthCompact :
                                                         kTOPagingViewBumperWidthRegular) * offsetModifier;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -24,6 +24,10 @@
 #import "TOPagingViewAnimator.h"
 #import <objc/runtime.h>
 
+@interface TOPagingViewAnimator ()
+- (void)animateOffset:(CGFloat)distance;
+@end
+
 /// Mark methods as being statically called to increase performance
 #define TOPAGINGVIEW_OBJC_DIRECT __attribute__((objc_direct))
 
@@ -984,8 +988,11 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     _currentPageView.frame = TOPagingViewCurrentPageFrame(self);
     TOPagingViewInsertPageView(self, _currentPageView);
 
-    // Set up the animator
-    _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
+    // Calculate the animation distance toward the center.
+    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
+    const CGFloat distance = (direction == UIRectEdgeLeft) ? -pageWidth : pageWidth;
+    _pageAnimator.pageWidth = pageWidth;
+    _pageAnimator.pageTransitionHandler = nil;
 
     // Set up the completion handler
     __weak __typeof(self) weakSelf = self;
@@ -1010,10 +1017,8 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Perform the skip animation via the same page turn mechanism.
-    // Since _disableLayout is YES, no transitions will fire — the
-    // animator simply slides the offset by one page width.
-    [_pageAnimator turnToPageInDirection:direction];
+    // Perform the skip animation as a one-shot offset change.
+    [_pageAnimator animateOffset:distance];
 }
 
 - (nullable __kindof UIView *)pageViewForUniqueIdentifier:(NSString *)identifier

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -902,7 +902,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Animate the page turn via CADisplayLink using logical distance and per-frame deltas.
+    // Animate the page turn via CADisplayLink using logical offsets relative to the center slot.
     _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
     [_pageAnimator turnToPageInDirection:direction];
 }

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -859,9 +859,12 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     }
 
-    // Send a delegate event stating the page is about to turn
-    if (_delegateFlags.delegateWillTurnToPage) {
-        TOPagingViewPageType type = (isPreviousPage ? TOPagingViewPageTypePrevious : TOPagingViewPageTypeNext);
+    // Only send the willTurn delegate for the first turn in a sequence.
+    // For subsequent taps during an animation, the animator will notify
+    // us via pageTransitionHandler when each page boundary is crossed,
+    // and we fire willTurn for the next page at that point.
+    const TOPagingViewPageType type = (isPreviousPage ? TOPagingViewPageTypePrevious : TOPagingViewPageTypeNext);
+    if (!_pageAnimator.isAnimating && _delegateFlags.delegateWillTurnToPage) {
         [_delegate pagingView:self willTurnToPageOfType:type];
     }
 
@@ -888,6 +891,17 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         id<UIScrollViewDelegate> scrollViewDelegate = strongSelf->_scrollViewDelegateProxy.externalDelegate;
         if ([scrollViewDelegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
             [scrollViewDelegate scrollViewDidEndScrollingAnimation:strongSelf->_scrollView];
+        }
+    };
+
+    // Set up the page transition handler — called after each page boundary
+    // crossing when more turns are still pending. This is where we fire
+    // willTurnToPageOfType: for the next page at the correct moment.
+    _pageAnimator.pageTransitionHandler = ^{
+        __strong __typeof(self) strongSelf = weakSelf;
+        if (strongSelf == nil) { return; }
+        if (strongSelf->_delegateFlags.delegateWillTurnToPage) {
+            [strongSelf->_delegate pagingView:strongSelf willTurnToPageOfType:type];
         }
     };
 
@@ -963,10 +977,8 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     _currentPageView.frame = TOPagingViewCurrentPageFrame(self);
     TOPagingViewInsertPageView(self, _currentPageView);
 
-    // Calculate the animation distance toward the center
-    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
-    const CGFloat distance = (direction == UIRectEdgeLeft) ? -pageWidth : pageWidth;
-    _pageAnimator.pageWidth = pageWidth;
+    // Set up the animator
+    _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
 
     // Set up the completion handler
     __weak __typeof(self) weakSelf = self;
@@ -991,8 +1003,10 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Perform the skip animation via CADisplayLink
-    [_pageAnimator animateOffset:distance];
+    // Perform the skip animation via the same page turn mechanism.
+    // Since _disableLayout is YES, no transitions will fire — the
+    // animator simply slides the offset by one page width.
+    [_pageAnimator turnToPageInDirection:direction];
 }
 
 - (nullable __kindof UIView *)pageViewForUniqueIdentifier:(NSString *)identifier

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -891,12 +891,11 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
         }
     };
 
-    // Animate by one page width in the target direction via CADisplayLink.
-    // The per-frame deltas allow the paging view's scroll handling to process
-    // page transitions naturally. If already animating, the remaining distance
-    // is aggregated with the new page turn and the timer restarts.
-    const CGFloat distance = isLeftDirection ? -TOPagingViewScrollViewPageWidth(self) : TOPagingViewScrollViewPageWidth(self);
-    [_pageAnimator animateDistance:distance];
+    // Animate the page turn via CADisplayLink. The animator determines the
+    // destination from the page width and the number of turns already queued.
+    // If already animating, the turn count increments and the timer restarts.
+    _pageAnimator.pageWidth = TOPagingViewScrollViewPageWidth(self);
+    [_pageAnimator turnToPageInDirection:direction];
 }
 
 - (void)_skipToNewPageInDirection:(UIRectEdge)direction animated:(BOOL)animated TOPAGINGVIEW_OBJC_DIRECT
@@ -965,7 +964,9 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     TOPagingViewInsertPageView(self, _currentPageView);
 
     // Calculate the animation distance toward the center
-    const CGFloat distance = (direction == UIRectEdgeLeft) ? -TOPagingViewScrollViewPageWidth(self) : TOPagingViewScrollViewPageWidth(self);
+    const CGFloat pageWidth = TOPagingViewScrollViewPageWidth(self);
+    const CGFloat distance = (direction == UIRectEdgeLeft) ? -pageWidth : pageWidth;
+    _pageAnimator.pageWidth = pageWidth;
 
     // Set up the completion handler
     __weak __typeof(self) weakSelf = self;
@@ -991,7 +992,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     };
 
     // Perform the skip animation via CADisplayLink
-    [_pageAnimator animateDistance:distance];
+    [_pageAnimator animateOffset:distance];
 }
 
 - (nullable __kindof UIView *)pageViewForUniqueIdentifier:(NSString *)identifier

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -26,19 +26,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Drives content offset animations for TOPagingView using CADisplayLink.
 ///
-/// Instead of a pre-canned UIViewPropertyAnimator animation, this class
-/// incrementally updates the scroll view's content offset each frame via
-/// per-frame deltas. This allows the hosting paging view's scroll handling
-/// logic to process page transitions naturally during the animation.
+/// Supports two modes of animation:
 ///
-/// If multiple animations are requested while one is already in progress,
-/// the remaining distance is combined with the new request and the timing
-/// restarts, producing smooth aggregation of rapid page turns.
+/// **Page turns** (`turnToPageInDirection:`) drive the offset from center toward
+/// the page edge each frame, letting the paging view's scroll handling fire
+/// transitions naturally. Multiple calls aggregate — each call adds one more
+/// page turn to the queue and restarts the easing timer from the current position.
+///
+/// **Offset animations** (`animateOffset:`) perform a simple one-shot slide
+/// of the content offset by a fixed distance, used for skip animations where
+/// the page layout is managed externally.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 
 /// The scroll view whose content offset will be animated.
 @property (nonatomic, weak, nullable) UIScrollView *scrollView;
+
+/// The width of one page segment in the scroll view (view width + page spacing).
+/// Must be set before calling `turnToPageInDirection:`.
+@property (nonatomic, assign) CGFloat pageWidth;
 
 /// The duration of each animation cycle in seconds (default 0.4).
 @property (nonatomic, assign) CFTimeInterval duration;
@@ -49,14 +55,25 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
-/// Starts or extends a content offset animation by the given horizontal distance.
+/// Queues a page turn animation in the given direction.
 ///
-/// If called while already animating, the remaining distance is combined
-/// with the new distance and the timing resets for a smooth continuation.
+/// The animator determines the destination offset from the current scroll position,
+/// the page width, and the number of page turns already queued. If called while
+/// already animating in the same direction, the turn count increments and the
+/// easing timer restarts from the current visual position.
+///
+/// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
+- (void)turnToPageInDirection:(UIRectEdge)direction;
+
+/// Performs a one-shot content offset animation by the given distance.
+///
+/// Unlike `turnToPageInDirection:`, this does not track page transitions
+/// or support aggregation. Used for skip animations where the caller
+/// manages page layout and disables automatic layout during the animation.
 ///
 /// @param distance The horizontal distance to animate in points
 ///                 (positive = right, negative = left).
-- (void)animateDistance:(CGFloat)distance;
+- (void)animateOffset:(CGFloat)distance;
 
 /// Immediately stops the current animation at its current position.
 - (void)stopAnimation;

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -1,0 +1,66 @@
+//
+//  TOPagingViewAnimator.h
+//
+//  Copyright 2018-2026 Timothy Oliver. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Drives content offset animations for TOPagingView using CADisplayLink.
+///
+/// Instead of a pre-canned UIViewPropertyAnimator animation, this class
+/// incrementally updates the scroll view's content offset each frame via
+/// per-frame deltas. This allows the hosting paging view's scroll handling
+/// logic to process page transitions naturally during the animation.
+///
+/// If multiple animations are requested while one is already in progress,
+/// the remaining distance is combined with the new request and the timing
+/// restarts, producing smooth aggregation of rapid page turns.
+NS_SWIFT_NAME(PagingViewAnimator)
+@interface TOPagingViewAnimator : NSObject
+
+/// The scroll view whose content offset will be animated.
+@property (nonatomic, weak, nullable) UIScrollView *scrollView;
+
+/// The duration of each animation cycle in seconds (default 0.4).
+@property (nonatomic, assign) CFTimeInterval duration;
+
+/// Whether an animation is currently in progress.
+@property (nonatomic, readonly) BOOL isAnimating;
+
+/// Called when the animation completes naturally (not when stopped mid-way).
+@property (nonatomic, copy, nullable) void (^completionHandler)(void);
+
+/// Starts or extends a content offset animation by the given horizontal distance.
+///
+/// If called while already animating, the remaining distance is combined
+/// with the new distance and the timing resets for a smooth continuation.
+///
+/// @param distance The horizontal distance to animate in points
+///                 (positive = right, negative = left).
+- (void)animateDistance:(CGFloat)distance;
+
+/// Immediately stops the current animation at its current position.
+- (void)stopAnimation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -60,6 +60,10 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Stops the animation if we are heading in a given direction (ie, we're about to run out of pages)
 - (void)stopAnimationInDirection:(UIRectEdge)direction;
 
+/// Returns YES if the animator is currently heading away from the given direction,
+/// meaning a page exists on that side even if hasNext/hasPrevious flags are stale.
+- (BOOL)hasRunwayInDirection:(UIRectEdge)direction;
+
 /// Called when the paging mechanism has performed a transition and all of the pages
 /// were offset. We pass the offset here so we can rebase the animator's logical
 /// offset relative to the middle slot.

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -26,9 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Drives content offset animations for TOPagingView using CADisplayLink.
 ///
-/// The animator keeps its own logical distance state and applies only the
-/// per-frame delta to the scroll view. This keeps the animation continuous
-/// even if TOPagingView recenters the content offset during page transitions.
+/// The animator keeps its own logical offset state relative to the middle slot
+/// and writes absolute content offsets into the scroll view each frame. This
+/// keeps the animation continuous even if TOPagingView recenters the content
+/// offset during page transitions.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -60,14 +60,6 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Immediately stops the current animation at its current position.
 - (void)stopAnimation;
 
-/// Stops the animation if we are heading in a given direction (ie, we're about to run out of pages)
-/// @return Whether it sucessfully canceled the animation or not. If true, a bounce animation should play.
-- (void)stopAnimationInDirection:(UIRectEdge)direction;
-
-/// Returns YES if the animator is currently heading away from the given direction,
-/// meaning a page exists on that side even if hasNext/hasPrevious flags are stale.
-- (BOOL)hasRunwayInDirection:(UIRectEdge)direction;
-
 /// Called when the paging mechanism has performed a transition and all of the pages
 /// were offset. We pass the offset here so we can rebase the animator's logical
 /// offset relative to the middle slot.

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -46,8 +46,8 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Whether an animation is currently in progress.
 @property (nonatomic, readonly) BOOL isAnimating;
 
-/// The velocity (in points/second) of the animation at the moment it was last stopped.
-@property (nonatomic, readonly) CGFloat velocity;
+/// The direction we're currently turning in
+@property (nonatomic, readonly) UIRectEdge direction;
 
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -24,13 +24,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Drives content offset animations for TOPagingView using CADisplayLink.
+/// Drives fixed content offset animations for TOPagingView using CADisplayLink.
 ///
-/// Each call to `turnToPageInDirection:` queues one page turn. The animator
-/// drives the scroll view's content offset toward the target each frame,
-/// letting the paging view's transition logic fire naturally as page
-/// boundaries are crossed. Multiple rapid calls aggregate — each adds one
-/// more page to the target and restarts the timer from the current position.
+/// Each call to `turnToPageInDirection:` animates the scroll view from its
+/// current offset to the predetermined edge for that direction.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 
@@ -50,17 +47,7 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
-/// Called after a page transition fires and more turns are still pending.
-/// Use this to fire delegate callbacks (e.g. willTurnToPageOfType:) for
-/// the next page turn at the appropriate moment in the animation flow.
-@property (nonatomic, copy, nullable) void (^pageTransitionHandler)(void);
-
-/// Queues a page turn animation in the given direction.
-///
-/// The animator computes the destination from the current scroll position,
-/// the page width, and the number of page turns already queued. If called
-/// while already animating in the same direction, the turn count increments
-/// and the easing timer restarts from the current visual position.
+/// Animates to the predetermined page offset in the given direction.
 ///
 /// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
 - (void)turnToPageInDirection:(UIRectEdge)direction;

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -46,6 +46,9 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Whether an animation is currently in progress.
 @property (nonatomic, readonly) BOOL isAnimating;
 
+/// The velocity (in points/second) of the animation at the moment it was last stopped.
+@property (nonatomic, readonly) CGFloat velocity;
+
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
@@ -59,7 +62,7 @@ NS_SWIFT_NAME(PagingViewAnimator)
 
 /// Stops the animation if we are heading in a given direction (ie, we're about to run out of pages)
 /// @return Whether it sucessfully canceled the animation or not. If true, a bounce animation should play.
-- (BOOL)stopAnimationInDirection:(UIRectEdge)direction;
+- (void)stopAnimationInDirection:(UIRectEdge)direction;
 
 /// Returns YES if the animator is currently heading away from the given direction,
 /// meaning a page exists on that side even if hasNext/hasPrevious flags are stale.

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -26,10 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Drives content offset animations for TOPagingView using CADisplayLink.
 ///
-/// The animator keeps its own logical offset state relative to the middle slot
-/// and writes absolute content offsets into the scroll view each frame. This
-/// keeps the animation continuous even if TOPagingView recenters the content
-/// offset during page transitions.
+/// The animator stores absolute `contentOffset.x` values and writes them
+/// directly into the scroll view each frame. When TOPagingView recenters the
+/// scroll view during page transitions, the animator is rebased by one page
+/// segment so the motion remains continuous.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 
@@ -61,8 +61,8 @@ NS_SWIFT_NAME(PagingViewAnimator)
 - (void)stopAnimation;
 
 /// Called when the paging mechanism has performed a transition and all of the pages
-/// were offset. We pass the offset here so we can rebase the animator's logical
-/// offset relative to the middle slot.
+/// were offset by one page segment. We pass that segment delta here so the
+/// animator can rebase its absolute content offset targets.
 - (void)didTransitionWithOffset:(CGFloat)offset;
 
 @end

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -57,6 +57,9 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Immediately stops the current animation at its current position.
 - (void)stopAnimation;
 
+/// Stops the animation if we are heading in a given direction (ie, we're about to run out of pages)
+- (void)stopAnimationInDirection:(UIRectEdge)direction;
+
 /// Called when the paging mechanism has performed a transition and all of the pages
 /// were offset. We pass the offset here so we can rebase the animator's logical
 /// offset relative to the middle slot.

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -62,10 +62,6 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// while already animating in the same direction, the turn count increments
 /// and the easing timer restarts from the current visual position.
 ///
-/// Also used for skip animations — when layout is externally disabled,
-/// no transitions fire and the animator simply slides the offset by one
-/// page width over the duration.
-///
 /// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
 - (void)turnToPageInDirection:(UIRectEdge)direction;
 

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -46,7 +46,7 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Whether an animation is currently in progress.
 @property (nonatomic, readonly) BOOL isAnimating;
 
-/// The direction we're currently turning in
+/// The direction we're currently turning in.
 @property (nonatomic, readonly) UIRectEdge direction;
 
 /// Called when the animation completes naturally (not when stopped mid-way).

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -58,7 +58,8 @@ NS_SWIFT_NAME(PagingViewAnimator)
 - (void)stopAnimation;
 
 /// Stops the animation if we are heading in a given direction (ie, we're about to run out of pages)
-- (void)stopAnimationInDirection:(UIRectEdge)direction;
+/// @return Whether it sucessfully canceled the animation or not. If true, a bounce animation should play.
+- (BOOL)stopAnimationInDirection:(UIRectEdge)direction;
 
 /// Returns YES if the animator is currently heading away from the given direction,
 /// meaning a page exists on that side even if hasNext/hasPrevious flags are stale.

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -24,10 +24,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Drives fixed content offset animations for TOPagingView using CADisplayLink.
+/// Drives content offset animations for TOPagingView using CADisplayLink.
 ///
-/// Each call to `turnToPageInDirection:` animates the scroll view from its
-/// current offset to the predetermined edge for that direction.
+/// The animator keeps its own logical distance state and applies only the
+/// per-frame delta to the scroll view. This keeps the animation continuous
+/// even if TOPagingView recenters the content offset during page transitions.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 
@@ -47,7 +48,7 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
-/// Animates to the predetermined page offset in the given direction.
+/// Animates toward the next page in the given direction.
 ///
 /// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
 - (void)turnToPageInDirection:(UIRectEdge)direction;

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -26,16 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Drives content offset animations for TOPagingView using CADisplayLink.
 ///
-/// Supports two modes of animation:
-///
-/// **Page turns** (`turnToPageInDirection:`) drive the offset from center toward
-/// the page edge each frame, letting the paging view's scroll handling fire
-/// transitions naturally. Multiple calls aggregate — each call adds one more
-/// page turn to the queue and restarts the easing timer from the current position.
-///
-/// **Offset animations** (`animateOffset:`) perform a simple one-shot slide
-/// of the content offset by a fixed distance, used for skip animations where
-/// the page layout is managed externally.
+/// Each call to `turnToPageInDirection:` queues one page turn. The animator
+/// drives the scroll view's content offset toward the target each frame,
+/// letting the paging view's transition logic fire naturally as page
+/// boundaries are crossed. Multiple rapid calls aggregate — each adds one
+/// more page to the target and restarts the timer from the current position.
 NS_SWIFT_NAME(PagingViewAnimator)
 @interface TOPagingViewAnimator : NSObject
 
@@ -55,25 +50,24 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
+/// Called after a page transition fires and more turns are still pending.
+/// Use this to fire delegate callbacks (e.g. willTurnToPageOfType:) for
+/// the next page turn at the appropriate moment in the animation flow.
+@property (nonatomic, copy, nullable) void (^pageTransitionHandler)(void);
+
 /// Queues a page turn animation in the given direction.
 ///
-/// The animator determines the destination offset from the current scroll position,
-/// the page width, and the number of page turns already queued. If called while
-/// already animating in the same direction, the turn count increments and the
-/// easing timer restarts from the current visual position.
+/// The animator computes the destination from the current scroll position,
+/// the page width, and the number of page turns already queued. If called
+/// while already animating in the same direction, the turn count increments
+/// and the easing timer restarts from the current visual position.
+///
+/// Also used for skip animations — when layout is externally disabled,
+/// no transitions fire and the animator simply slides the offset by one
+/// page width over the duration.
 ///
 /// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
 - (void)turnToPageInDirection:(UIRectEdge)direction;
-
-/// Performs a one-shot content offset animation by the given distance.
-///
-/// Unlike `turnToPageInDirection:`, this does not track page transitions
-/// or support aggregation. Used for skip animations where the caller
-/// manages page layout and disables automatic layout during the animation.
-///
-/// @param distance The horizontal distance to animate in points
-///                 (positive = right, negative = left).
-- (void)animateOffset:(CGFloat)distance;
 
 /// Immediately stops the current animation at its current position.
 - (void)stopAnimation;

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -58,7 +58,8 @@ NS_SWIFT_NAME(PagingViewAnimator)
 - (void)stopAnimation;
 
 /// Called when the paging mechanism has performed a transition and all of the pages
-/// were offset. We pass the offset here so we can adjust our animation distance to match.
+/// were offset. We pass the offset here so we can rebase the animator's logical
+/// offset relative to the middle slot.
 - (void)didTransitionWithOffset:(CGFloat)offset;
 
 @end

--- a/TOPagingView/TOPagingViewAnimator.h
+++ b/TOPagingView/TOPagingViewAnimator.h
@@ -56,6 +56,10 @@ NS_SWIFT_NAME(PagingViewAnimator)
 /// Immediately stops the current animation at its current position.
 - (void)stopAnimation;
 
+/// Called when the paging mechanism has performed a transition and all of the pages
+/// were offset. We pass the offset here so we can adjust our animation distance to match.
+- (void)didTransitionWithOffset:(CGFloat)offset;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -97,6 +97,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
+/// The direction we're turning in
+@property (nonatomic, assign, readwrite) UIRectEdge direction;
+
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
@@ -158,6 +161,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     // page boundary in the requested direction. This naturally handles reversal
     // (tap left while going right snaps back to the page on screen) as well as
     // re-initiating the original direction mid-reversal without drift.
+    _direction = direction;
     _turnDirection = dir;
     _startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
     _endOffset = (dir > 0.0f)

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -234,6 +234,7 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
 {
     _displayLink = [CADisplayLink displayLinkWithTarget:self
                                               selector:@selector(_displayLinkDidFire:)];
+    _displayLink.preferredFramesPerSecond = 120;
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop]
                        forMode:NSRunLoopCommonModes];
 }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -72,14 +72,35 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
 
-/// The time at which the current animation cycle started.
+/// The time at which the current easing cycle started.
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// The total distance to animate in the current cycle.
-@property (nonatomic, assign) CGFloat totalDistance;
+/// YES when running a one-shot offset animation (skip), NO for page turns.
+@property (nonatomic, assign) BOOL isOneShotAnimation;
 
-/// The cumulative eased distance applied to the content offset so far.
-@property (nonatomic, assign) CGFloat appliedDistance;
+// -- Page turn state --
+
+/// The total number of page turns requested during this animation.
+@property (nonatomic, assign) NSInteger targetTurns;
+
+/// The number of page turns fully completed (transitions fired).
+@property (nonatomic, assign) NSInteger completedTurns;
+
+/// The direction of the animation (+1 for right, -1 for left).
+@property (nonatomic, assign) CGFloat turnDirection;
+
+/// The fractional turn progress (0–1 within the current page) at the
+/// moment the easing timer was last reset. Used to avoid visual jumps
+/// when aggregating new page turns mid-animation.
+@property (nonatomic, assign) CGFloat turnFractionAtReset;
+
+// -- One-shot offset state --
+
+/// The starting content offset X for a one-shot animation.
+@property (nonatomic, assign) CGFloat offsetStartX;
+
+/// The total distance for a one-shot animation.
+@property (nonatomic, assign) CGFloat offsetDistance;
 
 @end
 
@@ -105,22 +126,50 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
 #pragma mark - Public Methods -
 
-- (void)animateDistance:(CGFloat)distance
+- (void)turnToPageInDirection:(UIRectEdge)direction
 {
-    if (_isAnimating) {
-        // Combine the remaining unapplied distance with the new distance
-        // and restart the timing curve from the current position
-        const CGFloat remainingDistance = _totalDistance - _appliedDistance;
-        _totalDistance = remainingDistance + distance;
-        _appliedDistance = 0.0f;
+    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+
+    if (_isAnimating && !_isOneShotAnimation && dir == _turnDirection) {
+        // Already animating page turns in the same direction.
+        // Capture the current visual position so the easing
+        // continues smoothly after the timer resets.
+        const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+        const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
+        const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
+        const NSInteger remainingTurns = _targetTurns - _completedTurns;
+        const CGFloat currentFraction = _turnFractionAtReset
+                                      + easedProgress * ((CGFloat)remainingTurns - _turnFractionAtReset);
+        _turnFractionAtReset = fmin(currentFraction, 1.0f);
+
+        // Queue one more turn and restart the easing timer
+        _targetTurns++;
         _startTime = CACurrentMediaTime();
     } else {
-        _totalDistance = distance;
-        _appliedDistance = 0.0f;
+        // Fresh page turn animation (or direction change)
+        if (_isAnimating) { [self stopAnimation]; }
+
+        _targetTurns = 1;
+        _completedTurns = 0;
+        _turnDirection = dir;
+        _turnFractionAtReset = 0.0f;
+        _isOneShotAnimation = NO;
         _startTime = CACurrentMediaTime();
         _isAnimating = YES;
         [self _createDisplayLink];
     }
+}
+
+- (void)animateOffset:(CGFloat)distance
+{
+    if (_isAnimating) { [self stopAnimation]; }
+
+    _offsetStartX = _scrollView.contentOffset.x;
+    _offsetDistance = distance;
+    _isOneShotAnimation = YES;
+    _startTime = CACurrentMediaTime();
+    _isAnimating = YES;
+    [self _createDisplayLink];
 }
 
 - (void)stopAnimation
@@ -154,22 +203,72 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
         return;
     }
 
-    // Calculate the current animation progress
+    if (_isOneShotAnimation) {
+        [self _updateOneShotAnimation:scrollView];
+    } else {
+        [self _updatePageTurnAnimation:scrollView];
+    }
+}
+
+#pragma mark - Page Turn Animation -
+
+- (void)_updatePageTurnAnimation:(UIScrollView *)scrollView
+{
+    const CGFloat center = _pageWidth;
+
+    // Calculate the current easing progress
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
 
-    // Work out the delta since the last frame
-    const CGFloat targetApplied = _totalDistance * easedProgress;
-    const CGFloat delta = targetApplied - _appliedDistance;
-    _appliedDistance = targetApplied;
+    // The easing covers all remaining turns in one sweep.
+    // It interpolates from turnFractionAtReset (the visual position when
+    // the timer last reset) through the total remaining turns.
+    const NSInteger remainingTurns = _targetTurns - _completedTurns;
+    const CGFloat totalFraction = _turnFractionAtReset
+                                + easedProgress * ((CGFloat)remainingTurns - _turnFractionAtReset);
 
-    // Apply the delta to the scroll view's content offset
-    CGPoint offset = scrollView.contentOffset;
-    offset.x += delta;
-    scrollView.contentOffset = offset;
+    // Clamp to one page width — the offset can only reach the edge of
+    // the current page slot. The transition handles the rest.
+    const CGFloat currentTurnFraction = fmin(totalFraction, 1.0f);
 
-    // Complete the animation once the full duration has elapsed
+    // Compute the desired offset: center + fraction * pageWidth * direction
+    const CGFloat desiredOffset = center + currentTurnFraction * _pageWidth * _turnDirection;
+    scrollView.contentOffset = (CGPoint){desiredOffset, 0.0f};
+
+    // Check if a page transition fired (offset was adjusted by ~pageWidth)
+    const CGFloat actualOffset = scrollView.contentOffset.x;
+    if (fabs(actualOffset - desiredOffset) > _pageWidth * 0.5f) {
+        // Transition fired. Snap to exact center and advance the counter.
+        _completedTurns++;
+        _turnFractionAtReset = 0.0f;
+        scrollView.contentOffset = (CGPoint){center, 0.0f};
+    }
+
+    // Complete the animation once all queued turns are done
+    if (_completedTurns >= _targetTurns) {
+        [self _destroyDisplayLink];
+        _isAnimating = NO;
+        scrollView.contentOffset = (CGPoint){center, 0.0f};
+        if (_completionHandler) {
+            _completionHandler();
+        }
+    }
+}
+
+#pragma mark - One-Shot Offset Animation -
+
+- (void)_updateOneShotAnimation:(UIScrollView *)scrollView
+{
+    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
+
+    // Interpolate from start to destination
+    const CGFloat currentOffset = _offsetStartX + _offsetDistance * easedProgress;
+    scrollView.contentOffset = (CGPoint){currentOffset, 0.0f};
+
+    // Complete when the easing finishes
     if (progress >= 1.0f) {
         [self _destroyDisplayLink];
         _isAnimating = NO;

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -178,8 +178,14 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
-    _startOffset += offset;
     _endOffset += offset;
+
+    // After the scroll view recenters, restart the easing clock from the new
+    // contentOffset. This keeps each animation segment's range equal to one
+    // page width, giving consistent velocity and deceleration regardless of
+    // how many taps were queued — identical feel to a single-tap animation.
+    _startOffset = _scrollView.contentOffset.x;
+    _startTime = CACurrentMediaTime();
 }
 
 #pragma mark - Display Link -
@@ -211,7 +217,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         return;
     }
 
-    const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
+    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -38,25 +38,18 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// The total number of page turns to animate through.
-@property (nonatomic, assign) NSInteger targetPages;
-
-/// The number of page boundaries crossed so far (transitions fired).
-@property (nonatomic, assign) NSInteger completedPages;
-
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The total distance to animate (targetPages * pageWidth). Always positive.
+/// The total distance to animate. Always positive.
+/// Incremented by pageWidth on each call to turnToPageInDirection:.
 @property (nonatomic, assign) CGFloat totalDistance;
 
 /// How much distance has been applied to the scroll view so far. Always positive.
-/// Snapped to an exact integer multiple of pageWidth after each transition.
+/// Snapped to the nearest multiple of pageWidth after each transition.
 @property (nonatomic, assign) CGFloat appliedDistance;
 
-/// The value of appliedDistance when the easing timer was last reset.
-/// Used as the interpolation start point so the animation continues
-/// smoothly from wherever the offset currently is.
+/// The value of appliedDistance when the timer was last reset.
 @property (nonatomic, assign) CGFloat startApplied;
 
 @end
@@ -88,27 +81,22 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
 
     if (_isAnimating && dir == _turnDirection) {
-        // Already animating in the same direction. Add another page
-        // and restart the timer so the animation covers from the
-        // current position to the new target in a fresh duration.
-        _targetPages++;
-        _totalDistance = (CGFloat)_targetPages * _pageWidth;
-        _startApplied = _appliedDistance;
-        _startTime = CACurrentMediaTime();
+        // Already animating in the same direction.
+        // Add one more page width of distance and restart the timer.
+        _totalDistance += _pageWidth;
     } else {
-        // Fresh page turn animation (or direction change)
+        // Fresh animation (or direction change)
         if (_isAnimating) { [self stopAnimation]; }
 
-        _targetPages = 1;
-        _completedPages = 0;
         _turnDirection = dir;
         _totalDistance = _pageWidth;
-        _appliedDistance = 0.0f;
-        _startApplied = 0.0f;
-        _startTime = CACurrentMediaTime();
         _isAnimating = YES;
         [self _createDisplayLink];
     }
+
+    _startApplied = 0.0;
+    _appliedDistance = 0.0f;
+    _startTime = CACurrentMediaTime();
 }
 
 - (void)stopAnimation
@@ -148,49 +136,41 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
 
-    // Interpolate the applied distance from startApplied → totalDistance.
+    // Interpolate from startApplied → totalDistance
     const CGFloat targetApplied = _startApplied + (_totalDistance - _startApplied) * progress;
     const CGFloat delta = targetApplied - _appliedDistance;
     _appliedDistance = targetApplied;
 
-    // Apply the delta to the scroll view in the turn direction.
-    // Setting contentOffset synchronously triggers scrollViewDidScroll,
-    // which may fire a page transition that adjusts the offset.
+    // Apply the delta to the scroll view in the turn direction
     CGPoint offset = scrollView.contentOffset;
     const CGFloat expectedOffset = offset.x + delta * _turnDirection;
     offset.x = expectedOffset;
     scrollView.contentOffset = offset;
 
-    // Check if a page transition fired (offset jumped by ~pageWidth).
-    // For skip animations where layout is disabled, no transition fires
-    // and this block is simply skipped.
-    const CGFloat actualOffset = scrollView.contentOffset.x;
-    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
-        // Transition fired. Snap the offset to exact center, and snap
-        // appliedDistance to an integer multiple of pageWidth to
-        // eliminate any floating-point drift between page turns.
-        _completedPages++;
-        _appliedDistance = (CGFloat)_completedPages * _pageWidth;
-        scrollView.contentOffset = (CGPoint){center, 0.0f};
+    // Check if a page transition fired (offset jumped by ~pageWidth)
+//    const CGFloat actualOffset = scrollView.contentOffset.x;
+//    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
+//        // Transition fired. Snap appliedDistance to the nearest page
+//        // boundary to eliminate floating-point drift, and snap the
+//        // offset to exact center.
+//        _appliedDistance = round(_appliedDistance / _pageWidth) * _pageWidth;
+//        scrollView.contentOffset = (CGPoint){center, 0.0f};
+//
+//        // If there's still distance remaining, notify the caller
+//        // so it can fire willTurnToPageOfType: for the next page.
+//        if (_appliedDistance < _totalDistance && _pageTransitionHandler) {
+//            _pageTransitionHandler();
+//        }
+//    }
 
-        // If more turns are pending, notify the caller so it can
-        // fire willTurnToPageOfType: for the next page turn.
-        if (_completedPages < _targetPages && _pageTransitionHandler) {
-            _pageTransitionHandler();
-        }
-    }
-
-    // Complete when the duration has elapsed. For page turns, all
-    // transitions will have fired by this point. For skip animations,
-    // the offset has reached the destination.
+    // Complete when the duration has elapsed
     if (progress >= 1.0f) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
 
-        // Snap to center as a final safety net
-        if (_pageWidth > FLT_EPSILON) {
-            scrollView.contentOffset = (CGPoint){center, 0.0f};
-        }
+//        if (_pageWidth > FLT_EPSILON) {
+//            scrollView.contentOffset = (CGPoint){center, 0.0f};
+//        }
 
         if (_completionHandler) {
             _completionHandler();

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -123,8 +123,8 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 /// The logical offset from the middle slot where this animation should end.
 @property (nonatomic, assign) CGFloat endOffset;
 
-/// The original scrollEnabled state before this animator temporarily disabled scrolling.
-@property (nonatomic, assign) BOOL originalScrollEnabled;
+/// The original pagingEnabled state before this animator temporarily disabled paging.
+@property (nonatomic, assign) BOOL originalPagingEnabled;
 
 @end
 
@@ -188,8 +188,8 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 
     if (!_isAnimating) {
         _isAnimating = YES;
-        _originalScrollEnabled = scrollView.scrollEnabled;
-        scrollView.scrollEnabled = NO;
+        _originalPagingEnabled = scrollView.pagingEnabled;
+        scrollView.pagingEnabled = NO;
         [self _createDisplayLink];
     }
 }
@@ -199,7 +199,7 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
-    _scrollView.scrollEnabled = _originalScrollEnabled;
+    _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
@@ -273,7 +273,7 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
         && fabs(TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)) - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
-        _scrollView.scrollEnabled = _originalScrollEnabled;
+        _scrollView.pagingEnabled = _originalPagingEnabled;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -203,28 +203,47 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 }
 
 - (BOOL)hasRunwayInDirection:(UIRectEdge)direction {
-    if (!_isAnimating) { return NO; }
-    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
-    return (_turnDirection != dir);
+    UIScrollView *scrollView = _scrollView;
+    if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return NO; }
+
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
+    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
+    const CGFloat offset = scrollView.contentOffset.x;
+    const CGFloat maxOffset = scrollView.contentSize.width - CGRectGetWidth(scrollView.bounds);
+
+    if (direction == UIRectEdgeRight) {
+        return offset < maxOffset - pixelSize;
+    } else {
+        return offset > pixelSize;
+    }
 }
 
-- (BOOL)stopAnimationInDirection:(UIRectEdge)direction {
+- (void)stopAnimationInDirection:(UIRectEdge)direction {
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
-    if (!_isAnimating || _turnDirection != dir) { return NO; }
+    UIScrollView *const scrollView = _scrollView;
+    if (!scrollView || !_isAnimating || _turnDirection != dir) { return; }
 
-    const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
+    // Capture the current velocity before stopping.
     const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                          : (CACurrentMediaTime() - _startTime);
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
-    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+    const CGFloat dp = 0.001f;
+    const CGFloat easingNow = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+    const CGFloat easingNext = TOPagingViewAnimatorEvaluateEasing(fmin(linearProgress + dp, 1.0f));
+    const CGFloat easingSlope = (easingNext - easingNow) / dp;
+    _velocity = (_endOffset - _startOffset) * easingSlope / (CGFloat)_duration;
 
-    const CGFloat remainingProgress = 1.0f - progress;
-    if (remainingProgress <= FLT_EPSILON) {
-        [self stopAnimation];
-        return YES;
-    }
+    [self stopAnimation];
 
-    return NO;
+    [UIView animateWithDuration:0.25f delay:0.0 usingSpringWithDamping:1.0 initialSpringVelocity:_velocity / 65.0f
+                        options:0 animations:^{
+        scrollView.contentOffset = (CGPoint){scrollView.contentOffset.x + (65.0f * dir), 0.0f};
+    } completion:^(BOOL finished) {
+        [UIView animateWithDuration:0.4f delay:0.0 usingSpringWithDamping:1.0 initialSpringVelocity:1.0f
+                            options:0 animations:^{
+            scrollView.contentOffset = (CGPoint){self->_pageWidth, 0.0f};
+        } completion:nil];
+    }];
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -202,6 +202,12 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
+- (BOOL)hasRunwayInDirection:(UIRectEdge)direction {
+    if (!_isAnimating) { return NO; }
+    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    return (_turnDirection != dir);
+}
+
 - (void)stopAnimationInDirection:(UIRectEdge)direction {
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     if (_turnDirection != dir) { return; }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -26,7 +26,41 @@
 // -----------------------------------------------------------------
 
 /// Default duration for page turn animations.
-static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
+static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
+
+/// Cubic bezier control points for the ease-out curve.
+static const CGFloat kTOAnimatorControlPoint1X = 0.3f;
+static const CGFloat kTOAnimatorControlPoint1Y = 0.9f;
+static const CGFloat kTOAnimatorControlPoint2X = 0.45f;
+static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
+
+// -----------------------------------------------------------------
+
+/// Evaluates a cubic bezier easing curve for the given linear time progress.
+/// @param t Linear time progress from 0.0 to 1.0.
+/// @return Eased progress from 0.0 to 1.0.
+static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
+    CGFloat u = t;
+    for (int i = 0; i < 8; i++) {
+        const CGFloat oneMinusU = 1.0f - u;
+        const CGFloat x = 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1X
+                        + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2X
+                        + u * u * u
+                        - t;
+        const CGFloat dx = 3.0f * oneMinusU * oneMinusU * kTOAnimatorControlPoint1X
+                         + 6.0f * oneMinusU * u * (kTOAnimatorControlPoint2X - kTOAnimatorControlPoint1X)
+                         + 3.0f * u * u * (1.0f - kTOAnimatorControlPoint2X);
+        if (fabs(dx) < 1e-6f) { break; }
+        u -= x / dx;
+    }
+    u = fmax(0.0f, fmin(1.0f, u));
+    const CGFloat oneMinusU = 1.0f - u;
+    return 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1Y
+         + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2Y
+         + u * u * u;
+}
+
+// -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
 
@@ -130,7 +164,8 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
     }
 
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
-    const CGFloat progress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetDistance = _startDistance + ((_endDistance - _startDistance) * progress);
     const CGFloat delta = targetDistance - _currentDistance;
     _currentDistance = targetDistance;
@@ -138,10 +173,10 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
     NSLog(@"delta: %f progress: %f offset: %f", delta, progress, _scrollView.contentOffset.x);
 
     CGPoint contentOffset = scrollView.contentOffset;
-    if (progress < 1.0f - FLT_EPSILON) {
+    if (linearProgress < 1.0f - FLT_EPSILON) {
         contentOffset.x += delta * _turnDirection;
     } else {
-        contentOffset.x = _scrollView.frame.size.width * 2.0f;
+        contentOffset.x = _scrollView.frame.size.width;
     }
     scrollView.contentOffset = contentOffset;
 

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -26,7 +26,7 @@
 // -----------------------------------------------------------------
 
 /// Default duration for page turn animations.
-static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
+static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 
 /// Cubic bezier control points for the ease-out curve.
 static const CGFloat kTOAnimatorControlPoint1X = 0.3f;
@@ -211,11 +211,6 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     if (_endDistance < _currentDistance) {
         _endDistance = _currentDistance;
     }
-
-    // Restart the easing cycle from the rebased position so the next frame
-    // doesn't evaluate the old progress value against the new bounds.
-    _startDistance = _currentDistance;
-    _startTime = CACurrentMediaTime();
 }
 
 #pragma mark - Display Link -

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -93,6 +93,17 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     return round(value * scale) / scale;
 }
 
+/// Converts an absolute content offset into a logical offset relative to the middle slot.
+static inline CGFloat TOPagingViewAnimatorLogicalOffset(CGFloat contentOffset, CGFloat pageWidth, CGFloat scale) {
+    const CGFloat logicalOffset = TOPagingViewAnimatorRoundToPixel(contentOffset - pageWidth, scale);
+    return TOPagingViewAnimatorClampNearZero(logicalOffset, scale);
+}
+
+/// Converts a logical offset relative to the middle slot back into an absolute content offset.
+static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, CGFloat pageWidth, CGFloat scale) {
+    return TOPagingViewAnimatorRoundToPixel(pageWidth + logicalOffset, scale);
+}
+
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
@@ -106,10 +117,10 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The offset value when we started.
+/// The logical offset from the middle slot when we started.
 @property (nonatomic, assign) CGFloat startOffset;
 
-/// The total target distance. This gets shrunk as we transition over boundaries.
+/// The logical offset from the middle slot where this animation should end.
 @property (nonatomic, assign) CGFloat endOffset;
 
 @end
@@ -152,7 +163,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
         const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
         _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
-        _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + _pageWidth, scale);
+        _startOffset = TOPagingViewAnimatorClampNearZero(_startOffset, scale);
+        _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
+        _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
         _startTime = now;
         return;
     }
@@ -162,11 +175,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     // (tap left while going right snaps back to the page on screen) as well as
     // re-initiating the original direction mid-reversal without drift.
     _turnDirection = dir;
-    _startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
+    _startOffset = TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, scale);
     _endOffset = (dir > 0.0f)
         ? ceil(_startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
         : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
+    _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
     _startTime = now;
 
     if (!_isAnimating) {
@@ -185,7 +199,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
-    const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
+    const CGFloat actualOffset = TOPagingViewAnimatorLogicalOffset(_scrollView.contentOffset.x, _pageWidth, scale);
     const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                          : (CACurrentMediaTime() - _startTime);
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
@@ -200,17 +214,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
     _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
 
-    // Keep the final destination locked to the newly rebased boundary so we
-    // don't reintroduce overshoot, and solve a synthetic start offset that
-    // makes the current presentation position continuous at the existing
-    // eased progress.
     const CGFloat remainingProgress = 1.0f - progress;
-    if (remainingProgress <= FLT_EPSILON) {
-        _startOffset = actualOffset;
-        _endOffset = actualOffset;
-        return;
-    }
-
     _startOffset = (actualOffset - (_endOffset * progress)) / remainingProgress;
     _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset, scale);
     _startOffset = TOPagingViewAnimatorSnapToPageBoundary(_startOffset, _pageWidth, scale);
@@ -250,16 +254,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    if (_turnDirection > 0.0f) {
-        targetOffset = fmin(targetOffset, _pageWidth * 2.0f);
-    } else {
-        targetOffset = fmax(targetOffset, 0.0f);
-    }
-    scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
-
+    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorAbsoluteOffset(targetOffset, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)), 0.0f};
+    NSLog(@"target %f, scroll offset: %f", targetOffset, scrollView.contentOffset.x);
+    
     const CGFloat pixelSize = 1.0f / TOPagingViewAnimatorDisplayScale(scrollView);
     if (progress >= 1.0f - FLT_EPSILON
-        && fabs(scrollView.contentOffset.x - _endOffset) <= pixelSize) {
+        && fabs(TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)) - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
         if (_completionHandler) {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -28,12 +28,6 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 
-/// Once the easing duration has elapsed, keep nudging by a tiny amount until
-/// the paging view commits the final threshold crossing.
-static const CGFloat kTOAnimatorCommitNudge = 1.0f;
-
-// -----------------------------------------------------------------
-
 @interface TOPagingViewAnimator ()
 
 /// The display link driving the frame-by-frame animation.
@@ -42,39 +36,11 @@ static const CGFloat kTOAnimatorCommitNudge = 1.0f;
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// YES when running a skip animation that does not trigger page transitions.
-@property (nonatomic, assign) BOOL isOneShotAnimation;
+/// The starting content offset X for the current animation.
+@property (nonatomic, assign) CGFloat startOffsetX;
 
-// -- Page turn state --
-
-/// The total number of page turns to animate through.
-@property (nonatomic, assign) NSInteger targetPages;
-
-/// The number of page boundaries crossed so far (transitions fired).
-@property (nonatomic, assign) NSInteger completedPages;
-
-/// The direction multiplier (+1 for right, -1 for left).
-@property (nonatomic, assign) CGFloat turnDirection;
-
-/// The total distance to animate (targetPages * pageWidth). Always positive.
-@property (nonatomic, assign) CGFloat totalDistance;
-
-/// How much distance has been applied to the scroll view so far. Always positive.
-/// Snapped to an exact integer multiple of pageWidth after each transition.
-@property (nonatomic, assign) CGFloat appliedDistance;
-
-/// The value of appliedDistance when the easing timer was last reset.
-/// Used as the interpolation start point so the animation continues
-/// smoothly from wherever the offset currently is.
-@property (nonatomic, assign) CGFloat startApplied;
-
-// -- One-shot offset state --
-
-/// The starting content offset X for a one-shot animation.
-@property (nonatomic, assign) CGFloat offsetStartX;
-
-/// The total distance for a one-shot animation.
-@property (nonatomic, assign) CGFloat offsetDistance;
+/// The destination content offset X for the current animation.
+@property (nonatomic, assign) CGFloat targetOffsetX;
 
 @end
 
@@ -102,40 +68,13 @@ static const CGFloat kTOAnimatorCommitNudge = 1.0f;
 
 - (void)turnToPageInDirection:(UIRectEdge)direction
 {
-    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    UIScrollView *const scrollView = _scrollView;
+    if (scrollView == nil) { return; }
 
-    if (_isAnimating && !_isOneShotAnimation && dir == _turnDirection) {
-        // Already animating in the same direction. Add another page
-        // and restart the timer so the animation covers from the
-        // current position to the new target in a fresh duration.
-        _targetPages++;
-        _totalDistance = (CGFloat)_targetPages * _pageWidth;
-        _startApplied = _appliedDistance;
-        _startTime = CACurrentMediaTime();
-    } else {
-        // Fresh page turn animation (or direction change)
-        if (_isAnimating) { [self stopAnimation]; }
-
-        _targetPages = 1;
-        _completedPages = 0;
-        _turnDirection = dir;
-        _totalDistance = _pageWidth;
-        _appliedDistance = 0.0f;
-        _startApplied = 0.0f;
-        _isOneShotAnimation = NO;
-        _startTime = CACurrentMediaTime();
-        _isAnimating = YES;
-        [self _createDisplayLink];
-    }
-}
-
-- (void)animateOffset:(CGFloat)distance
-{
     if (_isAnimating) { [self stopAnimation]; }
 
-    _offsetStartX = _scrollView.contentOffset.x;
-    _offsetDistance = distance;
-    _isOneShotAnimation = YES;
+    _startOffsetX = scrollView.contentOffset.x;
+    _targetOffsetX = (direction == UIRectEdgeRight) ? (_pageWidth * 2.0f) : 0.0f;
     _startTime = CACurrentMediaTime();
     _isAnimating = YES;
     [self _createDisplayLink];
@@ -146,7 +85,6 @@ static const CGFloat kTOAnimatorCommitNudge = 1.0f;
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
-    _isOneShotAnimation = NO;
 }
 
 #pragma mark - Display Link -
@@ -173,104 +111,14 @@ static const CGFloat kTOAnimatorCommitNudge = 1.0f;
         return;
     }
 
-    if (_isOneShotAnimation) {
-        [self _updateOneShotAnimation:scrollView];
-    } else {
-        [self _updatePageTurnAnimation:scrollView];
-    }
-}
-
-#pragma mark - Page Turn Animation -
-
-- (void)_updatePageTurnAnimation:(UIScrollView *)scrollView
-{
-    const CGFloat center = _pageWidth;
-
-    // Linear progress from the last timer reset
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-
-    // Interpolate the applied distance from startApplied -> totalDistance.
-    // This gives us the total cumulative delta that should have been
-    // output by this point in the animation.
-    const CGFloat targetApplied = _startApplied + (_totalDistance - _startApplied) * progress;
-    const CGFloat delta = targetApplied - _appliedDistance;
-    _appliedDistance = targetApplied;
-
-    // Apply the delta to the scroll view in the turn direction.
-    // Setting contentOffset synchronously triggers scrollViewDidScroll,
-    // which may fire a page transition that adjusts the offset.
-    CGPoint offset = scrollView.contentOffset;
-    const CGFloat expectedOffset = offset.x + delta * _turnDirection;
-    offset.x = expectedOffset;
-    scrollView.contentOffset = offset;
-
-    // Check if a page transition fired (offset jumped by ~pageWidth).
-    // For one-shot skip animations, this logic is bypassed entirely.
-    const CGFloat actualOffset = scrollView.contentOffset.x;
-    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
-        // Transition fired. Snap the offset to exact center, and snap
-        // appliedDistance to an exact integer multiple of pageWidth.
-        // This keeps the logical animation state in sync with the
-        // paging view after it recenters the scroll view.
-        _completedPages++;
-        _appliedDistance = (CGFloat)_completedPages * _pageWidth;
-        scrollView.contentOffset = (CGPoint){center, 0.0f};
-
-        // If more turns are still queued, notify the caller so it can
-        // prepare for the next turn at the correct point in the sequence.
-        if (_completedPages < _targetPages && _pageTransitionHandler) {
-            _pageTransitionHandler();
-        }
-    }
-
-    // If the easing duration elapsed exactly on the page boundary, the
-    // paging view may still need one more tick of movement before it
-    // commits the transition. Keep nudging until that happens.
-    if (progress >= 1.0f && _completedPages < _targetPages) {
-        CGPoint nudgedOffset = scrollView.contentOffset;
-        const CGFloat expectedNudgedOffset = nudgedOffset.x + (kTOAnimatorCommitNudge * _turnDirection);
-        nudgedOffset.x = expectedNudgedOffset;
-        scrollView.contentOffset = nudgedOffset;
-
-        const CGFloat actualNudgedOffset = scrollView.contentOffset.x;
-        if (_pageWidth > FLT_EPSILON && fabs(actualNudgedOffset - expectedNudgedOffset) > _pageWidth * 0.5f) {
-            _completedPages++;
-            _appliedDistance = (CGFloat)_completedPages * _pageWidth;
-            scrollView.contentOffset = (CGPoint){center, 0.0f};
-
-            if (_completedPages < _targetPages && _pageTransitionHandler) {
-                _pageTransitionHandler();
-            }
-        }
-    }
-
-    // Complete once all requested page boundaries have fired.
-    if (_completedPages >= _targetPages) {
-        [self _destroyDisplayLink];
-        _isAnimating = NO;
-        _isOneShotAnimation = NO;
-        scrollView.contentOffset = (CGPoint){center, 0.0f};
-        if (_completionHandler) {
-            _completionHandler();
-        }
-    }
-}
-
-#pragma mark - One-Shot Animation -
-
-- (void)_updateOneShotAnimation:(UIScrollView *)scrollView
-{
-    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
-    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-
-    const CGFloat currentOffset = _offsetStartX + (_offsetDistance * progress);
+    const CGFloat currentOffset = _startOffsetX + ((_targetOffsetX - _startOffsetX) * progress);
     scrollView.contentOffset = (CGPoint){currentOffset, 0.0f};
 
     if (progress >= 1.0f) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
-        _isOneShotAnimation = NO;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -64,6 +64,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
 @interface TOPagingViewAnimator () {
     CGFloat _delta;
+    CGFloat _currentOffset;
 }
 
 /// The display link driving the frame-by-frame animation.
@@ -132,7 +133,9 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     _startTime = now;
     _isAnimating = YES;
     _delta = 0.0;
+    _currentOffset = _scrollView.contentOffset.x;
     [self _createDisplayLink];
+    _scrollView.scrollEnabled = NO;
 }
 
 - (void)stopAnimation
@@ -140,6 +143,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+    _scrollView.scrollEnabled = YES;
 }
 
 #pragma mark - Display Link -
@@ -174,17 +178,17 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     _currentDistance = targetDistance;
 
     _delta += delta;
-
     NSLog(@"delta: %f totalDelta: %f linearProgress: %f progress: %f offset: %f", delta, _delta, linearProgress, progress, _scrollView.contentOffset.x);
 
-    CGPoint contentOffset = scrollView.contentOffset;
-    contentOffset.x += delta * _turnDirection;
-    scrollView.contentOffset = contentOffset;
+    // Track the offset at full precision to avoid sub-pixel rounding
+    // losses from reading back contentOffset each frame.
+    _currentOffset += delta * _turnDirection;
+    scrollView.contentOffset = (CGPoint){_currentOffset, 0.0f};
 
     if (_currentDistance >= _endDistance - FLT_EPSILON) {
         [self _destroyDisplayLink];
-        contentOffset.x = _scrollView.frame.size.width;
         _isAnimating = NO;
+        _scrollView.scrollEnabled = YES;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -64,6 +64,16 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
          + u * u * u;
 }
 
+/// Evaluates the slope of the easing curve at a given linear progress.
+static inline CGFloat TOPagingViewAnimatorEvaluateEasingSlope(CGFloat t) {
+    const CGFloat delta = 0.001f;
+    const CGFloat lower = fmax(0.0f, t - delta);
+    const CGFloat upper = fmin(1.0f, t + delta);
+    const CGFloat range = upper - lower;
+    if (range <= FLT_EPSILON) { return 0.0f; }
+    return (TOPagingViewAnimatorEvaluateEasing(upper) - TOPagingViewAnimatorEvaluateEasing(lower)) / range;
+}
+
 /// Returns the display scale used by the hosting scroll view, or the main screen as a fallback.
 static inline CGFloat TOPagingViewAnimatorDisplayScale(UIScrollView * _Nullable scrollView) {
     CGFloat scale = scrollView.window.screen.scale;
@@ -108,6 +118,12 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     return (effectiveDuration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / effectiveDuration, 1.0);
 }
 
+/// Clamps a duration into the short settle window used when an in-flight turn is cut short.
+static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInterval duration) {
+    const CFTimeInterval maxDuration = fmin(duration, 0.22);
+    return fmax(0.08, maxDuration);
+}
+
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
@@ -123,6 +139,9 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
 
 /// The direction we're turning in.
 @property (nonatomic, assign, readwrite) UIRectEdge direction;
+
+/// The duration of the current animation segment.
+@property (nonatomic, assign) CFTimeInterval activeDuration;
 
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
@@ -149,6 +168,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     self = [super init];
     if (self) {
         _duration = kTOAnimatorDefaultDuration;
+        _activeDuration = kTOAnimatorDefaultDuration;
     }
     return self;
 }
@@ -173,11 +193,12 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
         // Extend the animation one more page in the same direction.
         const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                              : (now - _startTime);
-        const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
+        const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
         const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
         _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
         _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
         _startTime = now;
+        _activeDuration = _duration;
         return;
     }
 
@@ -193,6 +214,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
         : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
     _startTime = now;
+    _activeDuration = _duration;
 
     if (!_isAnimating) {
         _isAnimating = YES;
@@ -207,6 +229,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+    _activeDuration = _duration;
     _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
@@ -220,8 +243,37 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     if (_turnDirection != dir) { return; }
 
-    // Clamp the remaining travel to the centered slot once we know there are no more pages.
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
+    const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
+    const CFTimeInterval now = CACurrentMediaTime();
+    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
+                                                         : (now - _startTime);
+    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+    const CGFloat easingSlope = TOPagingViewAnimatorEvaluateEasingSlope(linearProgress);
+    const CFTimeInterval effectiveDuration = TOPagingViewAnimatorEffectiveDuration(_activeDuration);
+    const CGFloat currentVelocity = (effectiveDuration <= FLT_EPSILON)
+        ? 0.0f
+        : (((_endOffset - _startOffset) * easingSlope) / effectiveDuration);
+    const CGFloat remainingDistance = _pageWidth - actualOffset;
+
+    // Re-seed the in-flight segment from the live on-screen position so clamping doesn't jump.
+    _startOffset = actualOffset;
     _endOffset = _pageWidth;
+    _startTime = now;
+
+    const CGFloat velocityTowardTarget = currentVelocity * ((remainingDistance >= 0.0f) ? 1.0f : -1.0f);
+    if (fabs(remainingDistance) <= (1.0f / fmax(scale, 1.0f))) {
+        _activeDuration = 0.0;
+        return;
+    }
+
+    if (velocityTowardTarget > FLT_EPSILON) {
+        const CGFloat startSlope = fmax(TOPagingViewAnimatorEvaluateEasingSlope(0.0f), 1.0f);
+        const CFTimeInterval settleDuration = (fabs(remainingDistance) * startSlope) / velocityTowardTarget;
+        _activeDuration = TOPagingViewAnimatorClampSettleDuration(settleDuration);
+    } else {
+        _activeDuration = TOPagingViewAnimatorClampSettleDuration(_duration * 0.45);
+    }
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset
@@ -231,7 +283,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
     const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                          : (CACurrentMediaTime() - _startTime);
-    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
+    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
 
     _endOffset += offset;
@@ -280,7 +332,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     }
 
     const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
-    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
+    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, TOPagingViewAnimatorDisplayScale(scrollView));

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -95,9 +95,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 // -----------------------------------------------------------------
 
-@interface TOPagingViewAnimator () {
-    CGFloat _currentOffset;
-}
+@interface TOPagingViewAnimator ()
 
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
@@ -108,14 +106,11 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The animated distance at the start of the current easing cycle.
-@property (nonatomic, assign) CGFloat startDistance;
+/// The offset value when we started.
+@property (nonatomic, assign) CGFloat startOffset;
 
-/// The total target distance for the current animation sequence.
-@property (nonatomic, assign) CGFloat endDistance;
-
-/// The amount of distance already applied to the scroll view.
-@property (nonatomic, assign) CGFloat currentDistance;
+/// The total target distance. This gets shrunk as we transition over boundaries.
+@property (nonatomic, assign) CGFloat endOffset;
 
 @end
 
@@ -154,37 +149,29 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
 
     if (_isAnimating && dir == _turnDirection) {
-        _startDistance = _currentDistance;
-        _endDistance += _pageWidth;
-        _endDistance = TOPagingViewAnimatorSnapToPageBoundary(_endDistance, _pageWidth, scale);
+        _endOffset += _pageWidth;
+        _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, scale);
         _startTime = now;
         return;
     }
 
     if (_isAnimating && fabs(distanceFromCenter) > pixelSize) {
-        // When reversing direction mid-turn, first settle back onto the
-        // currently committed page before allowing a full turn the other way.
-        _currentOffset = scrollView.contentOffset.x;
         _turnDirection = (distanceFromCenter > 0.0f) ? -1.0f : 1.0f;
-        _startDistance = 0.0f;
-        _currentDistance = 0.0f;
-        _endDistance = TOPagingViewAnimatorClampNearZero(fabs(distanceFromCenter), scale);
+        _startOffset = _scrollView.contentOffset.x;
+        _endOffset = TOPagingViewAnimatorClampNearZero(fabs(distanceFromCenter), scale);
         _startTime = now;
         return;
     }
 
     if (_isAnimating) { [self stopAnimation]; }
 
-    _currentOffset = _scrollView.contentOffset.x;
     _turnDirection = dir;
 
     // If we're starting mid-page (e.g. from a swipe), target the remaining
     // distance to the nearest page-turn boundary in this direction.
     const CGFloat boundaryOffset = _pageWidth + (_pageWidth * dir);
-    const CGFloat remainingDistance = (boundaryOffset - _currentOffset) * dir;
-    _startDistance = 0.0f;
-    _currentDistance = 0.0f;
-    _endDistance = TOPagingViewAnimatorClampNearZero(fmax(remainingDistance, 0.0f), scale);
+    const CGFloat remainingDistance = (boundaryOffset - _scrollView.contentOffset.x) * dir;
+    _endOffset = TOPagingViewAnimatorClampNearZero(fmax(remainingDistance, 0.0f), scale);
 
     _startTime = now;
     _isAnimating = YES;
@@ -196,6 +183,10 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+}
+
+- (void)didTransitionWithOffset:(CGFloat)offset {
+    
 }
 
 #pragma mark - Display Link -
@@ -226,32 +217,10 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    const CGFloat targetDistance = _startDistance + ((_endDistance - _startDistance) * progress);
-    CGFloat delta = targetDistance - _currentDistance;
-    _currentDistance += delta;
+    const CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
+    scrollView.contentOffset = (CGPoint){targetOffset * _turnDirection, 0.0f};
 
-    // Track the offset at full precision to avoid sub-pixel rounding
-    // losses from reading back contentOffset each frame.
-    if (progress < 1.0f - FLT_EPSILON) {
-        _currentOffset += delta * _turnDirection;
-    } else if (progress >= 1.0f && (_currentOffset < (_pageWidth * 0.5f) || _currentOffset > (_pageWidth * 1.5f))) {
-        // In the off chance the progression finishes, but we didn't hit the end threshold,
-        _currentOffset = _pageWidth + (_pageWidth * _turnDirection);
-    }
-    CGFloat previousOffset = scrollView.contentOffset.x;
-    scrollView.contentOffset = (CGPoint){_currentOffset, 0.0f};
-
-    // Once the scroll view goes over its boundary, it performs the transition and jumps
-    // back to the middle. This can happen in the final few ticks, so we'll use a fuzzy check here to stay in sync.
-    if (fabs(_currentOffset - scrollView.contentOffset.x) > (_pageWidth * 0.5f)) {
-        _currentOffset = _scrollView.contentOffset.x;
-        // Recalculate _currentDistance from the clean page count plus
-        // the actual partial offset from center, eliminating FP drift.
-        const CGFloat pagesCompleted = round(_currentDistance / _pageWidth);
-        _currentDistance = (pagesCompleted * _pageWidth) + ((_currentOffset - _pageWidth) * _turnDirection);
-    }
-
-    if (_currentDistance >= _endDistance - FLT_EPSILON) {
+    if (progress >= 1.0f - FLT_EPSILON) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
         if (_completionHandler) {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -82,26 +82,9 @@ static inline CGFloat TOPagingViewAnimatorSnapToPageBoundary(CGFloat value, CGFl
     return value;
 }
 
-/// Clamps extremely small values to zero using a one-pixel tolerance.
-static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat scale) {
-    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
-    return (fabs(value) <= pixelSize) ? 0.0f : value;
-}
-
 /// Rounds a value to the nearest screen pixel for the given display scale.
 static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat scale) {
     return round(value * scale) / scale;
-}
-
-/// Converts an absolute content offset into a logical offset relative to the middle slot.
-static inline CGFloat TOPagingViewAnimatorLogicalOffset(CGFloat contentOffset, CGFloat pageWidth, CGFloat scale) {
-    const CGFloat logicalOffset = TOPagingViewAnimatorRoundToPixel(contentOffset - pageWidth, scale);
-    return TOPagingViewAnimatorClampNearZero(logicalOffset, scale);
-}
-
-/// Converts a logical offset relative to the middle slot back into an absolute content offset.
-static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, CGFloat pageWidth, CGFloat scale) {
-    return TOPagingViewAnimatorRoundToPixel(pageWidth + logicalOffset, scale);
 }
 
 // -----------------------------------------------------------------
@@ -117,10 +100,10 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The logical offset from the middle slot when we started.
+/// The absolute scroll view content offset when we started.
 @property (nonatomic, assign) CGFloat startOffset;
 
-/// The logical offset from the middle slot where this animation should end.
+/// The absolute scroll view content offset where this animation should end.
 @property (nonatomic, assign) CGFloat endOffset;
 
 /// The original pagingEnabled state before this animator temporarily disabled paging.
@@ -166,9 +149,7 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
         const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
         const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
         _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
-        _startOffset = TOPagingViewAnimatorClampNearZero(_startOffset, scale);
         _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
-        _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
         _startTime = now;
         return;
     }
@@ -178,12 +159,11 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     // (tap left while going right snaps back to the page on screen) as well as
     // re-initiating the original direction mid-reversal without drift.
     _turnDirection = dir;
-    _startOffset = TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, scale);
+    _startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
     _endOffset = (dir > 0.0f)
         ? ceil(_startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
         : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
-    _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
     _startTime = now;
 
     if (!_isAnimating) {
@@ -205,20 +185,15 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
-    const CGFloat actualOffset = TOPagingViewAnimatorLogicalOffset(_scrollView.contentOffset.x, _pageWidth, scale);
+    const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
     const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                          : (CACurrentMediaTime() - _startTime);
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
 
     _endOffset += offset;
-    if (_pageWidth > FLT_EPSILON) {
-        // Keep the logical destination on an exact page multiple even if the
-        // scroll view crossed the threshold at a slightly rounded offset.
-        _endOffset = round(_endOffset / _pageWidth) * _pageWidth;
-    }
     _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
-    _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
+    _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, scale);
 
     const CGFloat remainingProgress = 1.0f - progress;
     if (remainingProgress <= FLT_EPSILON) {
@@ -230,7 +205,6 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     _startOffset = (actualOffset - (_endOffset * progress)) / remainingProgress;
     _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset, scale);
     _startOffset = TOPagingViewAnimatorSnapToPageBoundary(_startOffset, _pageWidth, scale);
-    _startOffset = TOPagingViewAnimatorClampNearZero(_startOffset, scale);
 }
 
 #pragma mark - Display Link -
@@ -266,11 +240,12 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorAbsoluteOffset(targetOffset, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)), 0.0f};
+    targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, TOPagingViewAnimatorDisplayScale(scrollView));
+    scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
     
     const CGFloat pixelSize = 1.0f / TOPagingViewAnimatorDisplayScale(scrollView);
     if (progress >= 1.0f - FLT_EPSILON
-        && fabs(TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)) - _endOffset) <= pixelSize) {
+        && fabs(scrollView.contentOffset.x - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
         _scrollView.pagingEnabled = _originalPagingEnabled;

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -202,50 +202,6 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
-- (BOOL)hasRunwayInDirection:(UIRectEdge)direction {
-    UIScrollView *scrollView = _scrollView;
-    if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return NO; }
-
-    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
-    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
-    const CGFloat offset = scrollView.contentOffset.x;
-    const CGFloat maxOffset = scrollView.contentSize.width - CGRectGetWidth(scrollView.bounds);
-
-    if (direction == UIRectEdgeRight) {
-        return offset < maxOffset - pixelSize;
-    } else {
-        return offset > pixelSize;
-    }
-}
-
-- (void)stopAnimationInDirection:(UIRectEdge)direction {
-    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
-    UIScrollView *const scrollView = _scrollView;
-    if (!scrollView || !_isAnimating || _turnDirection != dir) { return; }
-
-    // Capture the current velocity before stopping.
-    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
-                                                         : (CACurrentMediaTime() - _startTime);
-    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
-    const CGFloat dp = 0.001f;
-    const CGFloat easingNow = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    const CGFloat easingNext = TOPagingViewAnimatorEvaluateEasing(fmin(linearProgress + dp, 1.0f));
-    const CGFloat easingSlope = (easingNext - easingNow) / dp;
-    _velocity = (_endOffset - _startOffset) * easingSlope / (CGFloat)_duration;
-
-    [self stopAnimation];
-
-    [UIView animateWithDuration:0.25f delay:0.0 usingSpringWithDamping:1.0 initialSpringVelocity:_velocity / 65.0f
-                        options:0 animations:^{
-        scrollView.contentOffset = (CGPoint){scrollView.contentOffset.x + (65.0f * dir), 0.0f};
-    } completion:^(BOOL finished) {
-        [UIView animateWithDuration:0.4f delay:0.0 usingSpringWithDamping:1.0 initialSpringVelocity:1.0f
-                            options:0 animations:^{
-            scrollView.contentOffset = (CGPoint){self->_pageWidth, 0.0f};
-        } completion:nil];
-    }];
-}
-
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -126,14 +126,19 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
     if (_isAnimating) { [self stopAnimation]; }
 
+    _currentOffset = _scrollView.contentOffset.x;
     _turnDirection = dir;
+
+    // If we're starting mid-page (e.g. from a swipe), account for the
+    // existing offset from center so we land exactly on the boundary.
+    const CGFloat offsetFromCenter = (_currentOffset - _pageWidth) * dir;
     _startDistance = 0.0f;
     _currentDistance = 0.0f;
-    _endDistance = _pageWidth;
+    _endDistance = _pageWidth + (_pageWidth - offsetFromCenter);
+
     _startTime = now;
     _isAnimating = YES;
     _delta = 0.0;
-    _currentOffset = _scrollView.contentOffset.x;
     [self _createDisplayLink];
 }
 

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -28,6 +28,10 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 
+/// Once the easing duration has elapsed, keep nudging by a tiny amount until
+/// the paging view commits the final threshold crossing.
+static const CGFloat kTOAnimatorCommitNudge = 1.0f;
+
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
@@ -38,19 +42,39 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
+/// YES when running a skip animation that does not trigger page transitions.
+@property (nonatomic, assign) BOOL isOneShotAnimation;
+
+// -- Page turn state --
+
+/// The total number of page turns to animate through.
+@property (nonatomic, assign) NSInteger targetPages;
+
+/// The number of page boundaries crossed so far (transitions fired).
+@property (nonatomic, assign) NSInteger completedPages;
+
 /// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The total distance to animate. Always positive.
-/// Incremented by pageWidth on each call to turnToPageInDirection:.
+/// The total distance to animate (targetPages * pageWidth). Always positive.
 @property (nonatomic, assign) CGFloat totalDistance;
 
 /// How much distance has been applied to the scroll view so far. Always positive.
-/// Snapped to the nearest multiple of pageWidth after each transition.
+/// Snapped to an exact integer multiple of pageWidth after each transition.
 @property (nonatomic, assign) CGFloat appliedDistance;
 
-/// The value of appliedDistance when the timer was last reset.
+/// The value of appliedDistance when the easing timer was last reset.
+/// Used as the interpolation start point so the animation continues
+/// smoothly from wherever the offset currently is.
 @property (nonatomic, assign) CGFloat startApplied;
+
+// -- One-shot offset state --
+
+/// The starting content offset X for a one-shot animation.
+@property (nonatomic, assign) CGFloat offsetStartX;
+
+/// The total distance for a one-shot animation.
+@property (nonatomic, assign) CGFloat offsetDistance;
 
 @end
 
@@ -80,23 +104,41 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 {
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
 
-    if (_isAnimating && dir == _turnDirection) {
-        // Already animating in the same direction.
-        // Add one more page width of distance and restart the timer.
-        _totalDistance += _pageWidth;
+    if (_isAnimating && !_isOneShotAnimation && dir == _turnDirection) {
+        // Already animating in the same direction. Add another page
+        // and restart the timer so the animation covers from the
+        // current position to the new target in a fresh duration.
+        _targetPages++;
+        _totalDistance = (CGFloat)_targetPages * _pageWidth;
+        _startApplied = _appliedDistance;
+        _startTime = CACurrentMediaTime();
     } else {
-        // Fresh animation (or direction change)
+        // Fresh page turn animation (or direction change)
         if (_isAnimating) { [self stopAnimation]; }
 
+        _targetPages = 1;
+        _completedPages = 0;
         _turnDirection = dir;
         _totalDistance = _pageWidth;
+        _appliedDistance = 0.0f;
+        _startApplied = 0.0f;
+        _isOneShotAnimation = NO;
+        _startTime = CACurrentMediaTime();
         _isAnimating = YES;
         [self _createDisplayLink];
     }
+}
 
-    _startApplied = 0.0;
-    _appliedDistance = 0.0f;
+- (void)animateOffset:(CGFloat)distance
+{
+    if (_isAnimating) { [self stopAnimation]; }
+
+    _offsetStartX = _scrollView.contentOffset.x;
+    _offsetDistance = distance;
+    _isOneShotAnimation = YES;
     _startTime = CACurrentMediaTime();
+    _isAnimating = YES;
+    [self _createDisplayLink];
 }
 
 - (void)stopAnimation
@@ -104,6 +146,7 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+    _isOneShotAnimation = NO;
 }
 
 #pragma mark - Display Link -
@@ -130,48 +173,104 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
         return;
     }
 
+    if (_isOneShotAnimation) {
+        [self _updateOneShotAnimation:scrollView];
+    } else {
+        [self _updatePageTurnAnimation:scrollView];
+    }
+}
+
+#pragma mark - Page Turn Animation -
+
+- (void)_updatePageTurnAnimation:(UIScrollView *)scrollView
+{
     const CGFloat center = _pageWidth;
 
     // Linear progress from the last timer reset
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
 
-    // Interpolate from startApplied → totalDistance
+    // Interpolate the applied distance from startApplied -> totalDistance.
+    // This gives us the total cumulative delta that should have been
+    // output by this point in the animation.
     const CGFloat targetApplied = _startApplied + (_totalDistance - _startApplied) * progress;
     const CGFloat delta = targetApplied - _appliedDistance;
     _appliedDistance = targetApplied;
 
-    // Apply the delta to the scroll view in the turn direction
+    // Apply the delta to the scroll view in the turn direction.
+    // Setting contentOffset synchronously triggers scrollViewDidScroll,
+    // which may fire a page transition that adjusts the offset.
     CGPoint offset = scrollView.contentOffset;
     const CGFloat expectedOffset = offset.x + delta * _turnDirection;
     offset.x = expectedOffset;
     scrollView.contentOffset = offset;
 
-    // Check if a page transition fired (offset jumped by ~pageWidth)
-//    const CGFloat actualOffset = scrollView.contentOffset.x;
-//    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
-//        // Transition fired. Snap appliedDistance to the nearest page
-//        // boundary to eliminate floating-point drift, and snap the
-//        // offset to exact center.
-//        _appliedDistance = round(_appliedDistance / _pageWidth) * _pageWidth;
-//        scrollView.contentOffset = (CGPoint){center, 0.0f};
-//
-//        // If there's still distance remaining, notify the caller
-//        // so it can fire willTurnToPageOfType: for the next page.
-//        if (_appliedDistance < _totalDistance && _pageTransitionHandler) {
-//            _pageTransitionHandler();
-//        }
-//    }
+    // Check if a page transition fired (offset jumped by ~pageWidth).
+    // For one-shot skip animations, this logic is bypassed entirely.
+    const CGFloat actualOffset = scrollView.contentOffset.x;
+    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
+        // Transition fired. Snap the offset to exact center, and snap
+        // appliedDistance to an exact integer multiple of pageWidth.
+        // This keeps the logical animation state in sync with the
+        // paging view after it recenters the scroll view.
+        _completedPages++;
+        _appliedDistance = (CGFloat)_completedPages * _pageWidth;
+        scrollView.contentOffset = (CGPoint){center, 0.0f};
 
-    // Complete when the duration has elapsed
+        // If more turns are still queued, notify the caller so it can
+        // prepare for the next turn at the correct point in the sequence.
+        if (_completedPages < _targetPages && _pageTransitionHandler) {
+            _pageTransitionHandler();
+        }
+    }
+
+    // If the easing duration elapsed exactly on the page boundary, the
+    // paging view may still need one more tick of movement before it
+    // commits the transition. Keep nudging until that happens.
+    if (progress >= 1.0f && _completedPages < _targetPages) {
+        CGPoint nudgedOffset = scrollView.contentOffset;
+        const CGFloat expectedNudgedOffset = nudgedOffset.x + (kTOAnimatorCommitNudge * _turnDirection);
+        nudgedOffset.x = expectedNudgedOffset;
+        scrollView.contentOffset = nudgedOffset;
+
+        const CGFloat actualNudgedOffset = scrollView.contentOffset.x;
+        if (_pageWidth > FLT_EPSILON && fabs(actualNudgedOffset - expectedNudgedOffset) > _pageWidth * 0.5f) {
+            _completedPages++;
+            _appliedDistance = (CGFloat)_completedPages * _pageWidth;
+            scrollView.contentOffset = (CGPoint){center, 0.0f};
+
+            if (_completedPages < _targetPages && _pageTransitionHandler) {
+                _pageTransitionHandler();
+            }
+        }
+    }
+
+    // Complete once all requested page boundaries have fired.
+    if (_completedPages >= _targetPages) {
+        [self _destroyDisplayLink];
+        _isAnimating = NO;
+        _isOneShotAnimation = NO;
+        scrollView.contentOffset = (CGPoint){center, 0.0f};
+        if (_completionHandler) {
+            _completionHandler();
+        }
+    }
+}
+
+#pragma mark - One-Shot Animation -
+
+- (void)_updateOneShotAnimation:(UIScrollView *)scrollView
+{
+    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
+
+    const CGFloat currentOffset = _offsetStartX + (_offsetDistance * progress);
+    scrollView.contentOffset = (CGPoint){currentOffset, 0.0f};
+
     if (progress >= 1.0f) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
-
-//        if (_pageWidth > FLT_EPSILON) {
-//            scrollView.contentOffset = (CGPoint){center, 0.0f};
-//        }
-
+        _isOneShotAnimation = NO;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -223,6 +223,15 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     _currentDistance = TOPagingViewAnimatorClampNearZero(_currentDistance, scale);
     _endDistance = TOPagingViewAnimatorClampNearZero(_endDistance, scale);
 
+    // If the last requested page has already committed, clear any residual
+    // logical drift so the scroll view stays centered after rebasing.
+    if (_endDistance <= FLT_EPSILON) {
+        _startDistance = 0.0f;
+        _currentDistance = 0.0f;
+        _endDistance = 0.0f;
+        return;
+    }
+
     if (_endDistance < _currentDistance) {
         _endDistance = _currentDistance;
     }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -134,7 +134,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     const CGFloat offsetFromCenter = (_currentOffset - _pageWidth) * dir;
     _startDistance = 0.0f;
     _currentDistance = 0.0f;
-    _endDistance = _pageWidth + (_pageWidth - offsetFromCenter);
+    _endDistance = _pageWidth + offsetFromCenter;
 
     _startTime = now;
     _isAnimating = YES;

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -151,14 +151,15 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (_isAnimating && dir == _turnDirection) {
         _endOffset += _pageWidth;
         _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, scale);
+        _startOffset = scrollView.contentOffset.x;
         _startTime = now;
         return;
     }
 
     if (_isAnimating && fabs(distanceFromCenter) > pixelSize) {
         _turnDirection = (distanceFromCenter > 0.0f) ? -1.0f : 1.0f;
-        _startOffset = _scrollView.contentOffset.x;
-        _endOffset = TOPagingViewAnimatorClampNearZero(fabs(distanceFromCenter), scale);
+        _startOffset = scrollView.contentOffset.x;
+        _endOffset = centerOffset;
         _startTime = now;
         return;
     }
@@ -166,12 +167,8 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (_isAnimating) { [self stopAnimation]; }
 
     _turnDirection = dir;
-
-    // If we're starting mid-page (e.g. from a swipe), target the remaining
-    // distance to the nearest page-turn boundary in this direction.
-    const CGFloat boundaryOffset = _pageWidth + (_pageWidth * dir);
-    const CGFloat remainingDistance = (boundaryOffset - _scrollView.contentOffset.x) * dir;
-    _endOffset = TOPagingViewAnimatorClampNearZero(fmax(remainingDistance, 0.0f), scale);
+    _startOffset = scrollView.contentOffset.x;
+    _endOffset = _pageWidth + (_pageWidth * dir);
 
     _startTime = now;
     _isAnimating = YES;
@@ -186,7 +183,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
-    
+    if (!_isAnimating) { return; }
+    _startOffset += offset;
+    _endOffset += offset;
 }
 
 #pragma mark - Display Link -
@@ -195,7 +194,11 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 {
     _displayLink = [CADisplayLink displayLinkWithTarget:self
                                               selector:@selector(_displayLinkDidFire:)];
-    _displayLink.preferredFramesPerSecond = 120;
+    if (@available(iOS 15.0, *)) {
+        _displayLink.preferredFrameRateRange = CAFrameRateRangeMake(80.0, 120.0f, 120.0f);
+    } else {
+        _displayLink.preferredFramesPerSecond = 120;
+    }
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop]
                        forMode:NSRunLoopCommonModes];
 }
@@ -218,7 +221,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    scrollView.contentOffset = (CGPoint){targetOffset * _turnDirection, 0.0f};
+    scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
 
     if (progress >= 1.0f - FLT_EPSILON) {
         [self _destroyDisplayLink];

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -144,11 +144,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     const CFTimeInterval now = CACurrentMediaTime();
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
-    const CGFloat centerOffset = _pageWidth;
-    const CGFloat distanceFromCenter = scrollView.contentOffset.x - centerOffset;
-    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
 
     if (_isAnimating && dir == _turnDirection) {
+        // Extend the animation one more page in the same direction.
         _endOffset += _pageWidth;
         _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, scale);
         _startOffset = scrollView.contentOffset.x;
@@ -156,23 +154,21 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         return;
     }
 
-    if (_isAnimating && fabs(distanceFromCenter) > pixelSize) {
-        _turnDirection = (distanceFromCenter > 0.0f) ? -1.0f : 1.0f;
-        _startOffset = scrollView.contentOffset.x;
-        _endOffset = centerOffset;
-        _startTime = now;
-        return;
-    }
-
-    if (_isAnimating) { [self stopAnimation]; }
-
+    // New direction or fresh start: animate from the current position to the nearest
+    // page boundary in the requested direction. This naturally handles reversal
+    // (tap left while going right snaps back to the page on screen) as well as
+    // re-initiating the original direction mid-reversal without drift.
     _turnDirection = dir;
     _startOffset = scrollView.contentOffset.x;
-    _endOffset = _pageWidth + (_pageWidth * dir);
-
+    _endOffset = (dir > 0.0f)
+        ? ceil(_startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
+        : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     _startTime = now;
-    _isAnimating = YES;
-    [self _createDisplayLink];
+
+    if (!_isAnimating) {
+        _isAnimating = YES;
+        [self _createDisplayLink];
+    }
 }
 
 - (void)stopAnimation

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -112,7 +112,7 @@ static inline CGFloat TOPagingViewAnimatorAnimationDragCoefficient(void) {
 #endif
 }
 
-/// Returns the active simulator animation drag coefficient when Slow Animations is enabled.
+/// Returns a duration after applying the active simulator animation drag coefficient.
 static inline CFTimeInterval TOPagingViewAnimatorEffectiveDuration(CFTimeInterval duration) {
     return duration * TOPagingViewAnimatorAnimationDragCoefficient();
 }
@@ -128,7 +128,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
     return (effectiveDuration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / effectiveDuration, 1.0);
 }
 
-/// Clamps a duration into the short settle window used when an in-flight turn is cut short.
+/// Applies the minimum settle window used when an in-flight turn is cut short.
 static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInterval duration) {
     return fmax(0.05, duration);
 }
@@ -139,11 +139,19 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
 
 - (void)_createDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
 - (void)_destroyDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (CFTimeInterval)_referenceTimeWithFallbackTime:(CFTimeInterval)fallbackTime TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (CGFloat)_linearProgressAtReferenceTime:(CFTimeInterval)referenceTime TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (CGFloat)_presentationOffsetForProgress:(CGFloat)progress TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (void)_configureSegmentWithStartOffset:(CGFloat)startOffset
+                               endOffset:(CGFloat)endOffset
+                            referenceTime:(CFTimeInterval)referenceTime
+                                 duration:(CFTimeInterval)duration TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (void)_restorePagingState TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
 
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
 
-/// The time at which the current animation cycle started (reset on each tap).
+/// The time at which the current animation segment started.
 @property (nonatomic, assign) CFTimeInterval startTime;
 
 /// The direction we're turning in.
@@ -200,14 +208,14 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
 
     if (_isAnimating && dir == _turnDirection) {
         // Extend the animation one more page in the same direction.
-        const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
-                                                             : (now - _startTime);
-        const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+        const CGFloat linearProgress = [self _linearProgressAtReferenceTime:[self _referenceTimeWithFallbackTime:now]];
         const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-        _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
-        _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
-        _startTime = now;
-        _activeDuration = _duration;
+        const CGFloat currentOffset = TOPagingViewAnimatorRoundToPixel([self _presentationOffsetForProgress:progress], scale);
+        const CGFloat endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
+        [self _configureSegmentWithStartOffset:currentOffset
+                                     endOffset:endOffset
+                                  referenceTime:now
+                                       duration:_duration];
         return;
     }
 
@@ -217,13 +225,15 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     // re-initiating the original direction mid-reversal without drift.
     _direction = direction;
     _turnDirection = dir;
-    _startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
-    _endOffset = (dir > 0.0f)
-        ? ceil(_startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
-        : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
-    _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
-    _startTime = now;
-    _activeDuration = _duration;
+    const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
+    CGFloat endOffset = (dir > 0.0f)
+        ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
+        : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
+    endOffset = TOPagingViewAnimatorRoundToPixel(endOffset, scale);
+    [self _configureSegmentWithStartOffset:startOffset
+                                 endOffset:endOffset
+                              referenceTime:now
+                                   duration:_duration];
 
     if (!_isAnimating) {
         _isAnimating = YES;
@@ -238,8 +248,7 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
-    _activeDuration = _duration;
-    _scrollView.pagingEnabled = _originalPagingEnabled;
+    [self _restorePagingState];
 }
 
 - (void)clampAnimationToCurrentOffsetInDirection:(UIRectEdge)direction
@@ -255,9 +264,8 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
     const CFTimeInterval now = CACurrentMediaTime();
-    const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
-    const CFTimeInterval elapsed = referenceTime - _startTime;
-    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+    const CFTimeInterval referenceTime = [self _referenceTimeWithFallbackTime:now];
+    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:referenceTime];
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat easingSlope = TOPagingViewAnimatorEvaluateEasingSlope(linearProgress);
     const CFTimeInterval effectiveDuration = TOPagingViewAnimatorEffectiveDuration(_activeDuration);
@@ -268,10 +276,10 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
 
     const CGFloat velocityTowardTarget = currentVelocity * ((remainingDistance >= 0.0f) ? 1.0f : -1.0f);
     if (fabs(remainingDistance) <= (1.0f / fmax(scale, 1.0f))) {
-        _startOffset = actualOffset;
-        _endOffset = _pageWidth;
-        _startTime = referenceTime;
-        _activeDuration = 0.0;
+        [self _configureSegmentWithStartOffset:actualOffset
+                                     endOffset:_pageWidth
+                                  referenceTime:referenceTime
+                                       duration:0.0];
         return;
     }
 
@@ -290,18 +298,18 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
             const CFTimeInterval baseSettleDuration = TOPagingViewAnimatorClampSettleDuration(TOPagingViewAnimatorBaseDuration(effectiveSettleDuration));
             const CFTimeInterval adjustedEffectiveDuration = TOPagingViewAnimatorEffectiveDuration(baseSettleDuration);
 
-            _startOffset = syntheticStartOffset;
-            _endOffset = _pageWidth;
-            _startTime = referenceTime - (linearProgress * adjustedEffectiveDuration);
-            _activeDuration = baseSettleDuration;
+            [self _configureSegmentWithStartOffset:syntheticStartOffset
+                                         endOffset:_pageWidth
+                                      referenceTime:(referenceTime - (linearProgress * adjustedEffectiveDuration))
+                                           duration:baseSettleDuration];
             return;
         }
     }
 
-    _startOffset = actualOffset;
-    _endOffset = _pageWidth;
-    _startTime = referenceTime;
-    _activeDuration = TOPagingViewAnimatorClampSettleDuration(_duration * 0.45);
+    [self _configureSegmentWithStartOffset:actualOffset
+                                 endOffset:_pageWidth
+                              referenceTime:referenceTime
+                                   duration:TOPagingViewAnimatorClampSettleDuration(_duration * 0.45)];
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset
@@ -309,9 +317,7 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
-    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
-                                                         : (CACurrentMediaTime() - _startTime);
-    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:[self _referenceTimeWithFallbackTime:CACurrentMediaTime()]];
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
 
     _endOffset += offset;
@@ -331,6 +337,38 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
 }
 
 #pragma mark - Display Link -
+
+- (CFTimeInterval)_referenceTimeWithFallbackTime:(CFTimeInterval)fallbackTime TOPAGINGVIEWANIMATOR_OBJC_DIRECT
+{
+    return (_displayLink != nil) ? _displayLink.targetTimestamp : fallbackTime;
+}
+
+- (CGFloat)_linearProgressAtReferenceTime:(CFTimeInterval)referenceTime TOPAGINGVIEWANIMATOR_OBJC_DIRECT
+{
+    return TOPagingViewAnimatorLinearProgress(referenceTime - _startTime, _activeDuration);
+}
+
+- (CGFloat)_presentationOffsetForProgress:(CGFloat)progress TOPAGINGVIEWANIMATOR_OBJC_DIRECT
+{
+    return _startOffset + ((_endOffset - _startOffset) * progress);
+}
+
+- (void)_configureSegmentWithStartOffset:(CGFloat)startOffset
+                               endOffset:(CGFloat)endOffset
+                            referenceTime:(CFTimeInterval)referenceTime
+                                 duration:(CFTimeInterval)duration TOPAGINGVIEWANIMATOR_OBJC_DIRECT
+{
+    _startOffset = startOffset;
+    _endOffset = endOffset;
+    _startTime = referenceTime;
+    _activeDuration = duration;
+}
+
+- (void)_restorePagingState TOPAGINGVIEWANIMATOR_OBJC_DIRECT
+{
+    _activeDuration = _duration;
+    _scrollView.pagingEnabled = _originalPagingEnabled;
+}
 
 - (void)_createDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT
 {
@@ -359,19 +397,19 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
         return;
     }
 
-    const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
-    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
+    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, TOPagingViewAnimatorDisplayScale(scrollView));
+    CGFloat targetOffset = [self _presentationOffsetForProgress:progress];
+    targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, scale);
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
     
-    const CGFloat pixelSize = 1.0f / TOPagingViewAnimatorDisplayScale(scrollView);
+    const CGFloat pixelSize = 1.0f / scale;
     if (progress >= 1.0f - FLT_EPSILON
         && fabs(scrollView.contentOffset.x - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
-        _scrollView.pagingEnabled = _originalPagingEnabled;
+        [self _restorePagingState];
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -248,6 +248,10 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     // back to the middle. This can happen in the final few ticks, so we'll use a fuzzy check here to stay in sync.
     if (fabs(_currentOffset - scrollView.contentOffset.x) > (_pageWidth * 0.5f)) {
         _currentOffset = _scrollView.contentOffset.x;
+        // Recalculate _currentDistance from the clean page count plus
+        // the actual partial offset from center, eliminating FP drift.
+        const CGFloat pagesCompleted = round(_currentDistance / _pageWidth);
+        _currentDistance = (pagesCompleted * _pageWidth) + ((_currentOffset - _pageWidth) * _turnDirection);
     }
 
     if (_currentDistance >= _endDistance - FLT_EPSILON) {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -182,6 +182,19 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
+- (void)clampAnimationToCurrentOffsetInDirection:(UIRectEdge)direction
+{
+    if (!_isAnimating) { return; }
+
+    UIScrollView *const scrollView = _scrollView;
+    if (scrollView == nil) { return; }
+
+    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    if (_turnDirection != dir) { return; }
+    
+    _endOffset = _pageWidth;
+}
+
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -22,6 +22,7 @@
 
 #import "TOPagingViewAnimator.h"
 #import <QuartzCore/QuartzCore.h>
+#import <TargetConditionals.h>
 
 /// Mark implementation-only methods as being statically called to increase performance.
 #define TOPAGINGVIEWANIMATOR_OBJC_DIRECT __attribute__((objc_direct))
@@ -90,6 +91,23 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     return round(value * scale) / scale;
 }
 
+/// Returns the active simulator animation drag coefficient when Slow Animations is enabled.
+static inline CFTimeInterval TOPagingViewAnimatorEffectiveDuration(CFTimeInterval duration) {
+#if TARGET_OS_SIMULATOR
+    extern float UIAnimationDragCoefficient(void) __attribute__((weak_import));
+    const float dragCoefficient = (UIAnimationDragCoefficient != NULL) ? UIAnimationDragCoefficient() : 1.0f;
+    return duration * ((dragCoefficient > FLT_EPSILON) ? dragCoefficient : 1.0f);
+#else
+    return duration;
+#endif
+}
+
+/// Converts elapsed time into clamped linear animation progress.
+static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed, CFTimeInterval duration) {
+    const CFTimeInterval effectiveDuration = TOPagingViewAnimatorEffectiveDuration(duration);
+    return (effectiveDuration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / effectiveDuration, 1.0);
+}
+
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
@@ -155,7 +173,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         // Extend the animation one more page in the same direction.
         const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                              : (now - _startTime);
-        const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+        const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
         const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
         _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
         _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), scale);
@@ -213,7 +231,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
     const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
                                                          : (CACurrentMediaTime() - _startTime);
-    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
 
     _endOffset += offset;
@@ -262,7 +280,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     }
 
     const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
-    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _duration);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, TOPagingViewAnimatorDisplayScale(scrollView));

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -88,12 +88,9 @@ static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat s
     return (fabs(value) <= pixelSize) ? 0.0f : value;
 }
 
-/// The maximum distance that can be safely consumed in one frame without
-/// risking the pager jumping across multiple page boundaries before it can
-/// process the next scroll event.
-static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, CGFloat scale) {
-    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
-    return fmax(pageWidth - pixelSize, 0.0f);
+/// Rounds a value to the nearest screen pixel for the given display scale.
+static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat scale) {
+    return round(value * scale) / scale;
 }
 
 // -----------------------------------------------------------------

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -201,42 +201,6 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     _isAnimating = NO;
 }
 
-- (void)didTransition
-{
-    UIScrollView *const scrollView = _scrollView;
-    if (!_isAnimating || scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
-
-    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
-
-    // Re-base the logical distances whenever TOPagingView recenters the
-    // scroll view so that any overshoot is preserved, but stale page widths
-    // don't keep accumulating in the remaining target distance.
-    _currentOffset = scrollView.contentOffset.x;
-    _startDistance -= _pageWidth;
-    _currentDistance -= _pageWidth;
-    _endDistance -= _pageWidth;
-
-    _startDistance = TOPagingViewAnimatorSnapToPageBoundary(_startDistance, _pageWidth, scale);
-    _currentDistance = TOPagingViewAnimatorSnapToPageBoundary(_currentDistance, _pageWidth, scale);
-    _endDistance = TOPagingViewAnimatorSnapToPageBoundary(_endDistance, _pageWidth, scale);
-
-    _currentDistance = TOPagingViewAnimatorClampNearZero(_currentDistance, scale);
-    _endDistance = TOPagingViewAnimatorClampNearZero(_endDistance, scale);
-
-    // If the last requested page has already committed, clear any residual
-    // logical drift so the scroll view stays centered after rebasing.
-    if (_endDistance <= FLT_EPSILON) {
-        _startDistance = 0.0f;
-        _currentDistance = 0.0f;
-        _endDistance = 0.0f;
-        return;
-    }
-
-    if (_endDistance < _currentDistance) {
-        _endDistance = _currentDistance;
-    }
-}
-
 #pragma mark - Display Link -
 
 - (void)_createDisplayLink
@@ -267,13 +231,6 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetDistance = _startDistance + ((_endDistance - _startDistance) * progress);
     CGFloat delta = targetDistance - _currentDistance;
-    const CGFloat maxDelta = TOPagingViewAnimatorMaximumFrameDelta(_pageWidth,
-                                                                   TOPagingViewAnimatorDisplayScale(scrollView));
-    if (delta > maxDelta) {
-        delta = maxDelta;
-    } else if (delta < -maxDelta) {
-        delta = -maxDelta;
-    }
     _currentDistance += delta;
 
     // Track the offset at full precision to avoid sub-pixel rounding
@@ -284,6 +241,7 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
         // In the off chance the progression finishes, but we didn't hit the end threshold,
         _currentOffset = _pageWidth + (_pageWidth * _turnDirection);
     }
+    CGFloat previousOffset = scrollView.contentOffset.x;
     scrollView.contentOffset = (CGPoint){_currentOffset, 0.0f};
 
     // Once the scroll view goes over its boundary, it performs the transition and jumps

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -143,12 +143,10 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     const CFTimeInterval now = CACurrentMediaTime();
-    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
 
     if (_isAnimating && dir == _turnDirection) {
         // Extend the animation one more page in the same direction.
         _endOffset += _pageWidth;
-        _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, scale);
         _startOffset = scrollView.contentOffset.x;
         _startTime = now;
         return;

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -1,0 +1,182 @@
+//
+//  TOPagingViewAnimator.m
+//
+//  Copyright 2018-2026 Timothy Oliver. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TOPagingViewAnimator.h"
+#import <QuartzCore/QuartzCore.h>
+
+// -----------------------------------------------------------------
+
+/// Default duration for page turn animations.
+static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
+
+/// Cubic bezier control points for the ease-out curve.
+static const CGFloat kTOAnimatorControlPoint1X = 0.3f;
+static const CGFloat kTOAnimatorControlPoint1Y = 0.9f;
+static const CGFloat kTOAnimatorControlPoint2X = 0.45f;
+static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
+
+// -----------------------------------------------------------------
+
+/// Evaluates a cubic bezier easing curve for the given linear time progress.
+/// Uses Newton-Raphson iteration to find the parametric value, then
+/// evaluates the y-component for the eased output.
+/// @param t Linear time progress from 0.0 to 1.0.
+/// @return Eased progress from 0.0 to 1.0.
+static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
+    // Use Newton-Raphson to solve for the parameter u where x(u) = t
+    CGFloat u = t;
+    for (int i = 0; i < 8; i++) {
+        const CGFloat oneMinusU = 1.0f - u;
+        const CGFloat x = 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1X
+                        + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2X
+                        + u * u * u
+                        - t;
+        const CGFloat dx = 3.0f * oneMinusU * oneMinusU * kTOAnimatorControlPoint1X
+                         + 6.0f * oneMinusU * u * (kTOAnimatorControlPoint2X - kTOAnimatorControlPoint1X)
+                         + 3.0f * u * u * (1.0f - kTOAnimatorControlPoint2X);
+        if (fabs(dx) < 1e-6f) { break; }
+        u -= x / dx;
+    }
+    u = fmax(0.0f, fmin(1.0f, u));
+
+    // Evaluate y(u) to get the eased value
+    const CGFloat oneMinusU = 1.0f - u;
+    return 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1Y
+         + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2Y
+         + u * u * u;
+}
+
+// -----------------------------------------------------------------
+
+@interface TOPagingViewAnimator ()
+
+/// The display link driving the frame-by-frame animation.
+@property (nonatomic, strong, nullable) CADisplayLink *displayLink;
+
+/// The time at which the current animation cycle started.
+@property (nonatomic, assign) CFTimeInterval startTime;
+
+/// The total distance to animate in the current cycle.
+@property (nonatomic, assign) CGFloat totalDistance;
+
+/// The cumulative eased distance applied to the content offset so far.
+@property (nonatomic, assign) CGFloat appliedDistance;
+
+@end
+
+// -----------------------------------------------------------------
+
+@implementation TOPagingViewAnimator
+
+#pragma mark - Object Lifecycle -
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _duration = kTOAnimatorDefaultDuration;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [_displayLink invalidate];
+}
+
+#pragma mark - Public Methods -
+
+- (void)animateDistance:(CGFloat)distance
+{
+    if (_isAnimating) {
+        // Combine the remaining unapplied distance with the new distance
+        // and restart the timing curve from the current position
+        const CGFloat remainingDistance = _totalDistance - _appliedDistance;
+        _totalDistance = remainingDistance + distance;
+        _appliedDistance = 0.0f;
+        _startTime = CACurrentMediaTime();
+    } else {
+        _totalDistance = distance;
+        _appliedDistance = 0.0f;
+        _startTime = CACurrentMediaTime();
+        _isAnimating = YES;
+        [self _createDisplayLink];
+    }
+}
+
+- (void)stopAnimation
+{
+    if (!_isAnimating) { return; }
+    [self _destroyDisplayLink];
+    _isAnimating = NO;
+}
+
+#pragma mark - Display Link -
+
+- (void)_createDisplayLink
+{
+    _displayLink = [CADisplayLink displayLinkWithTarget:self
+                                              selector:@selector(_displayLinkDidFire:)];
+    [_displayLink addToRunLoop:[NSRunLoop mainRunLoop]
+                       forMode:NSRunLoopCommonModes];
+}
+
+- (void)_destroyDisplayLink
+{
+    [_displayLink invalidate];
+    _displayLink = nil;
+}
+
+- (void)_displayLinkDidFire:(CADisplayLink *)displayLink
+{
+    UIScrollView *const scrollView = _scrollView;
+    if (scrollView == nil) {
+        [self stopAnimation];
+        return;
+    }
+
+    // Calculate the current animation progress
+    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
+
+    // Work out the delta since the last frame
+    const CGFloat targetApplied = _totalDistance * easedProgress;
+    const CGFloat delta = targetApplied - _appliedDistance;
+    _appliedDistance = targetApplied;
+
+    // Apply the delta to the scroll view's content offset
+    CGPoint offset = scrollView.contentOffset;
+    offset.x += delta;
+    scrollView.contentOffset = offset;
+
+    // Complete the animation once the full duration has elapsed
+    if (progress >= 1.0f) {
+        [self _destroyDisplayLink];
+        _isAnimating = NO;
+        if (_completionHandler) {
+            _completionHandler();
+        }
+    }
+}
+
+@end

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -211,7 +211,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         return;
     }
 
-    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -28,43 +28,6 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 
-/// Cubic bezier control points for the ease-out curve.
-static const CGFloat kTOAnimatorControlPoint1X = 0.3f;
-static const CGFloat kTOAnimatorControlPoint1Y = 0.9f;
-static const CGFloat kTOAnimatorControlPoint2X = 0.45f;
-static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
-
-// -----------------------------------------------------------------
-
-/// Evaluates a cubic bezier easing curve for the given linear time progress.
-/// Uses Newton-Raphson iteration to find the parametric value, then
-/// evaluates the y-component for the eased output.
-/// @param t Linear time progress from 0.0 to 1.0.
-/// @return Eased progress from 0.0 to 1.0.
-static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
-    // Use Newton-Raphson to solve for the parameter u where x(u) = t
-    CGFloat u = t;
-    for (int i = 0; i < 8; i++) {
-        const CGFloat oneMinusU = 1.0f - u;
-        const CGFloat x = 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1X
-                        + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2X
-                        + u * u * u
-                        - t;
-        const CGFloat dx = 3.0f * oneMinusU * oneMinusU * kTOAnimatorControlPoint1X
-                         + 6.0f * oneMinusU * u * (kTOAnimatorControlPoint2X - kTOAnimatorControlPoint1X)
-                         + 3.0f * u * u * (1.0f - kTOAnimatorControlPoint2X);
-        if (fabs(dx) < 1e-6f) { break; }
-        u -= x / dx;
-    }
-    u = fmax(0.0f, fmin(1.0f, u));
-
-    // Evaluate y(u) to get the eased value
-    const CGFloat oneMinusU = 1.0f - u;
-    return 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1Y
-         + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2Y
-         + u * u * u;
-}
-
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator ()
@@ -72,35 +35,29 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
 
-/// The time at which the current easing cycle started.
+/// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// YES when running a one-shot offset animation (skip), NO for page turns.
-@property (nonatomic, assign) BOOL isOneShotAnimation;
+/// The total number of page turns to animate through.
+@property (nonatomic, assign) NSInteger targetPages;
 
-// -- Page turn state --
+/// The number of page boundaries crossed so far (transitions fired).
+@property (nonatomic, assign) NSInteger completedPages;
 
-/// The total number of page turns requested during this animation.
-@property (nonatomic, assign) NSInteger targetTurns;
-
-/// The number of page turns fully completed (transitions fired).
-@property (nonatomic, assign) NSInteger completedTurns;
-
-/// The direction of the animation (+1 for right, -1 for left).
+/// The direction multiplier (+1 for right, -1 for left).
 @property (nonatomic, assign) CGFloat turnDirection;
 
-/// The fractional turn progress (0–1 within the current page) at the
-/// moment the easing timer was last reset. Used to avoid visual jumps
-/// when aggregating new page turns mid-animation.
-@property (nonatomic, assign) CGFloat turnFractionAtReset;
+/// The total distance to animate (targetPages * pageWidth). Always positive.
+@property (nonatomic, assign) CGFloat totalDistance;
 
-// -- One-shot offset state --
+/// How much distance has been applied to the scroll view so far. Always positive.
+/// Snapped to an exact integer multiple of pageWidth after each transition.
+@property (nonatomic, assign) CGFloat appliedDistance;
 
-/// The starting content offset X for a one-shot animation.
-@property (nonatomic, assign) CGFloat offsetStartX;
-
-/// The total distance for a one-shot animation.
-@property (nonatomic, assign) CGFloat offsetDistance;
+/// The value of appliedDistance when the easing timer was last reset.
+/// Used as the interpolation start point so the animation continues
+/// smoothly from wherever the offset currently is.
+@property (nonatomic, assign) CGFloat startApplied;
 
 @end
 
@@ -130,46 +87,28 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 {
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
 
-    if (_isAnimating && !_isOneShotAnimation && dir == _turnDirection) {
-        // Already animating page turns in the same direction.
-        // Capture the current visual position so the easing
-        // continues smoothly after the timer resets.
-        const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
-        const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-        const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
-        const NSInteger remainingTurns = _targetTurns - _completedTurns;
-        const CGFloat currentFraction = _turnFractionAtReset
-                                      + easedProgress * ((CGFloat)remainingTurns - _turnFractionAtReset);
-        _turnFractionAtReset = fmin(currentFraction, 1.0f);
-
-        // Queue one more turn and restart the easing timer
-        _targetTurns++;
+    if (_isAnimating && dir == _turnDirection) {
+        // Already animating in the same direction. Add another page
+        // and restart the timer so the animation covers from the
+        // current position to the new target in a fresh duration.
+        _targetPages++;
+        _totalDistance = (CGFloat)_targetPages * _pageWidth;
+        _startApplied = _appliedDistance;
         _startTime = CACurrentMediaTime();
     } else {
         // Fresh page turn animation (or direction change)
         if (_isAnimating) { [self stopAnimation]; }
 
-        _targetTurns = 1;
-        _completedTurns = 0;
+        _targetPages = 1;
+        _completedPages = 0;
         _turnDirection = dir;
-        _turnFractionAtReset = 0.0f;
-        _isOneShotAnimation = NO;
+        _totalDistance = _pageWidth;
+        _appliedDistance = 0.0f;
+        _startApplied = 0.0f;
         _startTime = CACurrentMediaTime();
         _isAnimating = YES;
         [self _createDisplayLink];
     }
-}
-
-- (void)animateOffset:(CGFloat)distance
-{
-    if (_isAnimating) { [self stopAnimation]; }
-
-    _offsetStartX = _scrollView.contentOffset.x;
-    _offsetDistance = distance;
-    _isOneShotAnimation = YES;
-    _startTime = CACurrentMediaTime();
-    _isAnimating = YES;
-    [self _createDisplayLink];
 }
 
 - (void)stopAnimation
@@ -203,75 +142,56 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
         return;
     }
 
-    if (_isOneShotAnimation) {
-        [self _updateOneShotAnimation:scrollView];
-    } else {
-        [self _updatePageTurnAnimation:scrollView];
-    }
-}
-
-#pragma mark - Page Turn Animation -
-
-- (void)_updatePageTurnAnimation:(UIScrollView *)scrollView
-{
     const CGFloat center = _pageWidth;
 
-    // Calculate the current easing progress
+    // Linear progress from the last timer reset
     const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
     const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-    const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
 
-    // The easing covers all remaining turns in one sweep.
-    // It interpolates from turnFractionAtReset (the visual position when
-    // the timer last reset) through the total remaining turns.
-    const NSInteger remainingTurns = _targetTurns - _completedTurns;
-    const CGFloat totalFraction = _turnFractionAtReset
-                                + easedProgress * ((CGFloat)remainingTurns - _turnFractionAtReset);
+    // Interpolate the applied distance from startApplied → totalDistance.
+    const CGFloat targetApplied = _startApplied + (_totalDistance - _startApplied) * progress;
+    const CGFloat delta = targetApplied - _appliedDistance;
+    _appliedDistance = targetApplied;
 
-    // Clamp to one page width — the offset can only reach the edge of
-    // the current page slot. The transition handles the rest.
-    const CGFloat currentTurnFraction = fmin(totalFraction, 1.0f);
+    // Apply the delta to the scroll view in the turn direction.
+    // Setting contentOffset synchronously triggers scrollViewDidScroll,
+    // which may fire a page transition that adjusts the offset.
+    CGPoint offset = scrollView.contentOffset;
+    const CGFloat expectedOffset = offset.x + delta * _turnDirection;
+    offset.x = expectedOffset;
+    scrollView.contentOffset = offset;
 
-    // Compute the desired offset: center + fraction * pageWidth * direction
-    const CGFloat desiredOffset = center + currentTurnFraction * _pageWidth * _turnDirection;
-    scrollView.contentOffset = (CGPoint){desiredOffset, 0.0f};
-
-    // Check if a page transition fired (offset was adjusted by ~pageWidth)
+    // Check if a page transition fired (offset jumped by ~pageWidth).
+    // For skip animations where layout is disabled, no transition fires
+    // and this block is simply skipped.
     const CGFloat actualOffset = scrollView.contentOffset.x;
-    if (fabs(actualOffset - desiredOffset) > _pageWidth * 0.5f) {
-        // Transition fired. Snap to exact center and advance the counter.
-        _completedTurns++;
-        _turnFractionAtReset = 0.0f;
+    if (_pageWidth > FLT_EPSILON && fabs(actualOffset - expectedOffset) > _pageWidth * 0.5f) {
+        // Transition fired. Snap the offset to exact center, and snap
+        // appliedDistance to an integer multiple of pageWidth to
+        // eliminate any floating-point drift between page turns.
+        _completedPages++;
+        _appliedDistance = (CGFloat)_completedPages * _pageWidth;
         scrollView.contentOffset = (CGPoint){center, 0.0f};
-    }
 
-    // Complete the animation once all queued turns are done
-    if (_completedTurns >= _targetTurns) {
-        [self _destroyDisplayLink];
-        _isAnimating = NO;
-        scrollView.contentOffset = (CGPoint){center, 0.0f};
-        if (_completionHandler) {
-            _completionHandler();
+        // If more turns are pending, notify the caller so it can
+        // fire willTurnToPageOfType: for the next page turn.
+        if (_completedPages < _targetPages && _pageTransitionHandler) {
+            _pageTransitionHandler();
         }
     }
-}
 
-#pragma mark - One-Shot Offset Animation -
-
-- (void)_updateOneShotAnimation:(UIScrollView *)scrollView
-{
-    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
-    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-    const CGFloat easedProgress = TOPagingViewAnimatorEvaluateEasing(progress);
-
-    // Interpolate from start to destination
-    const CGFloat currentOffset = _offsetStartX + _offsetDistance * easedProgress;
-    scrollView.contentOffset = (CGPoint){currentOffset, 0.0f};
-
-    // Complete when the easing finishes
+    // Complete when the duration has elapsed. For page turns, all
+    // transitions will have fired by this point. For skip animations,
+    // the offset has reached the destination.
     if (progress >= 1.0f) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
+
+        // Snap to center as a final safety net
+        if (_pageWidth > FLT_EPSILON) {
+            scrollView.contentOffset = (CGPoint){center, 0.0f};
+        }
+
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -26,7 +26,7 @@
 // -----------------------------------------------------------------
 
 /// Default duration for page turn animations.
-static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
+static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
 
 /// Cubic bezier control points for the ease-out curve.
 static const CGFloat kTOAnimatorControlPoint1X = 0.3f;
@@ -58,6 +58,34 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     return 3.0f * oneMinusU * oneMinusU * u * kTOAnimatorControlPoint1Y
          + 3.0f * oneMinusU * u * u * kTOAnimatorControlPoint2Y
          + u * u * u;
+}
+
+/// Returns the display scale used by the hosting scroll view, or the main screen as a fallback.
+static inline CGFloat TOPagingViewAnimatorDisplayScale(UIScrollView * _Nullable scrollView) {
+    CGFloat scale = scrollView.window.screen.scale;
+    if (scale <= FLT_EPSILON) {
+        scale = scrollView.traitCollection.displayScale;
+    }
+    return (scale <= FLT_EPSILON) ? 1.0f : scale;
+}
+
+/// Snaps a value to the nearest page boundary only when already within one pixel of that boundary.
+static inline CGFloat TOPagingViewAnimatorSnapToPageBoundary(CGFloat value, CGFloat pageWidth, CGFloat scale) {
+    if (pageWidth <= FLT_EPSILON) { return value; }
+
+    const CGFloat nearestPageBoundary = round(value / pageWidth) * pageWidth;
+    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
+    if (fabs(value - nearestPageBoundary) <= pixelSize) {
+        return nearestPageBoundary;
+    }
+
+    return value;
+}
+
+/// Clamps extremely small values to zero using a one-pixel tolerance.
+static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat scale) {
+    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
+    return (fabs(value) <= pixelSize) ? 0.0f : value;
 }
 
 // -----------------------------------------------------------------
@@ -115,11 +143,12 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     const CFTimeInterval now = CACurrentMediaTime();
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
 
     if (_isAnimating && dir == _turnDirection) {
         _startDistance = _currentDistance;
         _endDistance += _pageWidth;
-        _endDistance = round(_endDistance / _pageWidth) * _pageWidth;
+        _endDistance = TOPagingViewAnimatorSnapToPageBoundary(_endDistance, _pageWidth, scale);
         _startTime = now;
         return;
     }
@@ -129,12 +158,13 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     _currentOffset = _scrollView.contentOffset.x;
     _turnDirection = dir;
 
-    // If we're starting mid-page (e.g. from a swipe), account for the
-    // existing offset from center so we land exactly on the boundary.
-    const CGFloat offsetFromCenter = (_currentOffset - _pageWidth) * dir;
+    // If we're starting mid-page (e.g. from a swipe), target the remaining
+    // distance to the nearest page-turn boundary in this direction.
+    const CGFloat boundaryOffset = _pageWidth + (_pageWidth * dir);
+    const CGFloat remainingDistance = (boundaryOffset - _currentOffset) * dir;
     _startDistance = 0.0f;
     _currentDistance = 0.0f;
-    _endDistance = _pageWidth + offsetFromCenter;
+    _endDistance = TOPagingViewAnimatorClampNearZero(fmax(remainingDistance, 0.0f), scale);
 
     _startTime = now;
     _isAnimating = YES;
@@ -146,6 +176,33 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+}
+
+- (void)didTransition
+{
+    UIScrollView *const scrollView = _scrollView;
+    if (!_isAnimating || scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
+
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
+
+    // Re-base the logical distances whenever TOPagingView recenters the
+    // scroll view so that any overshoot is preserved, but stale page widths
+    // don't keep accumulating in the remaining target distance.
+    _currentOffset = scrollView.contentOffset.x;
+    _startDistance -= _pageWidth;
+    _currentDistance -= _pageWidth;
+    _endDistance -= _pageWidth;
+
+    _startDistance = TOPagingViewAnimatorSnapToPageBoundary(_startDistance, _pageWidth, scale);
+    _currentDistance = TOPagingViewAnimatorSnapToPageBoundary(_currentDistance, _pageWidth, scale);
+    _endDistance = TOPagingViewAnimatorSnapToPageBoundary(_endDistance, _pageWidth, scale);
+
+    _currentDistance = TOPagingViewAnimatorClampNearZero(_currentDistance, scale);
+    _endDistance = TOPagingViewAnimatorClampNearZero(_endDistance, scale);
+
+    if (_endDistance < _currentDistance) {
+        _endDistance = _currentDistance;
+    }
 }
 
 #pragma mark - Display Link -

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -62,7 +62,9 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
 // -----------------------------------------------------------------
 
-@interface TOPagingViewAnimator ()
+@interface TOPagingViewAnimator () {
+    CGFloat _delta;
+}
 
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
@@ -129,6 +131,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     _endDistance = _pageWidth;
     _startTime = now;
     _isAnimating = YES;
+    _delta = 0.0;
     [self _createDisplayLink];
 }
 
@@ -170,18 +173,17 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     const CGFloat delta = targetDistance - _currentDistance;
     _currentDistance = targetDistance;
 
-    NSLog(@"delta: %f progress: %f offset: %f", delta, progress, _scrollView.contentOffset.x);
+    _delta += delta;
+
+    NSLog(@"delta: %f totalDelta: %f linearProgress: %f progress: %f offset: %f", delta, _delta, linearProgress, progress, _scrollView.contentOffset.x);
 
     CGPoint contentOffset = scrollView.contentOffset;
-    if (linearProgress < 1.0f - FLT_EPSILON) {
-        contentOffset.x += delta * _turnDirection;
-    } else {
-        contentOffset.x = _scrollView.frame.size.width;
-    }
+    contentOffset.x += delta * _turnDirection;
     scrollView.contentOffset = contentOffset;
 
     if (_currentDistance >= _endDistance - FLT_EPSILON) {
         [self _destroyDisplayLink];
+        contentOffset.x = _scrollView.frame.size.width;
         _isAnimating = NO;
         if (_completionHandler) {
             _completionHandler();

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -142,12 +142,17 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
 
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
     const CFTimeInterval now = CACurrentMediaTime();
 
     if (_isAnimating && dir == _turnDirection) {
         // Extend the animation one more page in the same direction.
-        _endOffset += _pageWidth;
-        _startOffset = scrollView.contentOffset.x;
+        const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
+                                                             : (now - _startTime);
+        const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+        const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+        _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), scale);
+        _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + _pageWidth, scale);
         _startTime = now;
         return;
     }
@@ -157,10 +162,11 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     // (tap left while going right snaps back to the page on screen) as well as
     // re-initiating the original direction mid-reversal without drift.
     _turnDirection = dir;
-    _startOffset = scrollView.contentOffset.x;
+    _startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
     _endOffset = (dir > 0.0f)
         ? ceil(_startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
         : floor(_startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
+    _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
     _startTime = now;
 
     if (!_isAnimating) {
@@ -178,14 +184,37 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
-    _endOffset += offset;
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
+    const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
+    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
+                                                         : (CACurrentMediaTime() - _startTime);
+    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
 
-    // After the scroll view recenters, restart the easing clock from the new
-    // contentOffset. This keeps each animation segment's range equal to one
-    // page width, giving consistent velocity and deceleration regardless of
-    // how many taps were queued — identical feel to a single-tap animation.
-    _startOffset = _scrollView.contentOffset.x;
-    _startTime = CACurrentMediaTime();
+    _endOffset += offset;
+    if (_pageWidth > FLT_EPSILON) {
+        // Keep the logical destination on an exact page multiple even if the
+        // scroll view crossed the threshold at a slightly rounded offset.
+        _endOffset = round(_endOffset / _pageWidth) * _pageWidth;
+    }
+    _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, scale);
+    _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
+
+    // Keep the final destination locked to the newly rebased boundary so we
+    // don't reintroduce overshoot, and solve a synthetic start offset that
+    // makes the current presentation position continuous at the existing
+    // eased progress.
+    const CGFloat remainingProgress = 1.0f - progress;
+    if (remainingProgress <= FLT_EPSILON) {
+        _startOffset = actualOffset;
+        _endOffset = actualOffset;
+        return;
+    }
+
+    _startOffset = (actualOffset - (_endOffset * progress)) / remainingProgress;
+    _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset, scale);
+    _startOffset = TOPagingViewAnimatorSnapToPageBoundary(_startOffset, _pageWidth, scale);
+    _startOffset = TOPagingViewAnimatorClampNearZero(_startOffset, scale);
 }
 
 #pragma mark - Display Link -
@@ -217,13 +246,20 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         return;
     }
 
-    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CFTimeInterval elapsed = displayLink.targetTimestamp - _startTime;
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    const CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
+    CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
+    if (_turnDirection > 0.0f) {
+        targetOffset = fmin(targetOffset, _pageWidth * 2.0f);
+    } else {
+        targetOffset = fmax(targetOffset, 0.0f);
+    }
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
 
-    if (progress >= 1.0f - FLT_EPSILON) {
+    const CGFloat pixelSize = 1.0f / TOPagingViewAnimatorDisplayScale(scrollView);
+    if (progress >= 1.0f - FLT_EPSILON
+        && fabs(scrollView.contentOffset.x - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
         if (_completionHandler) {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -202,6 +202,12 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     _scrollView.pagingEnabled = _originalPagingEnabled;
 }
 
+- (void)stopAnimationInDirection:(UIRectEdge)direction {
+    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    if (_turnDirection != dir) { return; }
+    [self stopAnimation];
+}
+
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -152,11 +152,26 @@ static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, C
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     const CFTimeInterval now = CACurrentMediaTime();
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
+    const CGFloat centerOffset = _pageWidth;
+    const CGFloat distanceFromCenter = scrollView.contentOffset.x - centerOffset;
+    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
 
     if (_isAnimating && dir == _turnDirection) {
         _startDistance = _currentDistance;
         _endDistance += _pageWidth;
         _endDistance = TOPagingViewAnimatorSnapToPageBoundary(_endDistance, _pageWidth, scale);
+        _startTime = now;
+        return;
+    }
+
+    if (_isAnimating && fabs(distanceFromCenter) > pixelSize) {
+        // When reversing direction mid-turn, first settle back onto the
+        // currently committed page before allowing a full turn the other way.
+        _currentOffset = scrollView.contentOffset.x;
+        _turnDirection = (distanceFromCenter > 0.0f) ? -1.0f : 1.0f;
+        _startDistance = 0.0f;
+        _currentDistance = 0.0f;
+        _endDistance = TOPagingViewAnimatorClampNearZero(fabs(distanceFromCenter), scale);
         _startTime = now;
         return;
     }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -88,6 +88,14 @@ static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat s
     return (fabs(value) <= pixelSize) ? 0.0f : value;
 }
 
+/// The maximum distance that can be safely consumed in one frame without
+/// risking the pager jumping across multiple page boundaries before it can
+/// process the next scroll event.
+static inline CGFloat TOPagingViewAnimatorMaximumFrameDelta(CGFloat pageWidth, CGFloat scale) {
+    const CGFloat pixelSize = 1.0f / fmax(scale, 1.0f);
+    return fmax(pageWidth - pixelSize, 0.0f);
+}
+
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator () {
@@ -203,6 +211,11 @@ static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat s
     if (_endDistance < _currentDistance) {
         _endDistance = _currentDistance;
     }
+
+    // Restart the easing cycle from the rebased position so the next frame
+    // doesn't evaluate the old progress value against the new bounds.
+    _startDistance = _currentDistance;
+    _startTime = CACurrentMediaTime();
 }
 
 #pragma mark - Display Link -
@@ -233,8 +246,15 @@ static inline CGFloat TOPagingViewAnimatorClampNearZero(CGFloat value, CGFloat s
     const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat targetDistance = _startDistance + ((_endDistance - _startDistance) * progress);
-    const CGFloat delta = targetDistance - _currentDistance;
-    _currentDistance = targetDistance;
+    CGFloat delta = targetDistance - _currentDistance;
+    const CGFloat maxDelta = TOPagingViewAnimatorMaximumFrameDelta(_pageWidth,
+                                                                   TOPagingViewAnimatorDisplayScale(scrollView));
+    if (delta > maxDelta) {
+        delta = maxDelta;
+    } else if (delta < -maxDelta) {
+        delta = -maxDelta;
+    }
+    _currentDistance += delta;
 
     // Track the offset at full precision to avoid sub-pixel rounding
     // losses from reading back contentOffset each frame.

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -135,7 +135,6 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     _delta = 0.0;
     _currentOffset = _scrollView.contentOffset.x;
     [self _createDisplayLink];
-    _scrollView.scrollEnabled = NO;
 }
 
 - (void)stopAnimation
@@ -143,7 +142,6 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
-    _scrollView.scrollEnabled = YES;
 }
 
 #pragma mark - Display Link -
@@ -177,18 +175,26 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     const CGFloat delta = targetDistance - _currentDistance;
     _currentDistance = targetDistance;
 
-    _delta += delta;
-    NSLog(@"delta: %f totalDelta: %f linearProgress: %f progress: %f offset: %f", delta, _delta, linearProgress, progress, _scrollView.contentOffset.x);
-
     // Track the offset at full precision to avoid sub-pixel rounding
     // losses from reading back contentOffset each frame.
     _currentOffset += delta * _turnDirection;
     scrollView.contentOffset = (CGPoint){_currentOffset, 0.0f};
 
+    NSLog(@"delta: %f totalDelta: %f linearProgress: %f progress: %f current: %f, scrolloffset: %f",
+          delta, _delta, linearProgress, progress, _currentOffset, _scrollView.contentOffset.x);
+
+    // When the offset crosses a page boundary, wrap it back to center.
+    // This keeps our tracked offset in sync with the scroll view's
+    // transition logic which resets the offset after a page turn.
+    const CGFloat rightEdge = _pageWidth * 2.0f;
+    if (rightEdge - _currentOffset < 0.5f ||
+        _currentOffset < 0.5f + FLT_EPSILON) {
+        _currentOffset = _scrollView.contentOffset.x;
+    }
+
     if (_currentDistance >= _endDistance - FLT_EPSILON) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
-        _scrollView.scrollEnabled = YES;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -63,7 +63,6 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 // -----------------------------------------------------------------
 
 @interface TOPagingViewAnimator () {
-    CGFloat _delta;
     CGFloat _currentOffset;
 }
 
@@ -120,6 +119,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     if (_isAnimating && dir == _turnDirection) {
         _startDistance = _currentDistance;
         _endDistance += _pageWidth;
+        _endDistance = round(_endDistance / _pageWidth) * _pageWidth;
         _startTime = now;
         return;
     }
@@ -138,7 +138,6 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
     _startTime = now;
     _isAnimating = YES;
-    _delta = 0.0;
     [self _createDisplayLink];
 }
 
@@ -182,18 +181,17 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
 
     // Track the offset at full precision to avoid sub-pixel rounding
     // losses from reading back contentOffset each frame.
-    _currentOffset += delta * _turnDirection;
+    if (progress < 1.0f - FLT_EPSILON) {
+        _currentOffset += delta * _turnDirection;
+    } else if (progress >= 1.0f && (_currentOffset < (_pageWidth * 0.5f) || _currentOffset > (_pageWidth * 1.5f))) {
+        // In the off chance the progression finishes, but we didn't hit the end threshold,
+        _currentOffset = _pageWidth + (_pageWidth * _turnDirection);
+    }
     scrollView.contentOffset = (CGPoint){_currentOffset, 0.0f};
 
-    NSLog(@"delta: %f totalDelta: %f linearProgress: %f progress: %f current: %f, scrolloffset: %f",
-          delta, _delta, linearProgress, progress, _currentOffset, _scrollView.contentOffset.x);
-
-    // When the offset crosses a page boundary, wrap it back to center.
-    // This keeps our tracked offset in sync with the scroll view's
-    // transition logic which resets the offset after a page turn.
-    const CGFloat rightEdge = _pageWidth * 2.0f;
-    if (rightEdge - _currentOffset < 0.5f ||
-        _currentOffset < 0.5f + FLT_EPSILON) {
+    // Once the scroll view goes over its boundary, it performs the transition and jumps
+    // back to the middle. This can happen in the final few ticks, so we'll use a fuzzy check here to stay in sync.
+    if (fabs(_currentOffset - scrollView.contentOffset.x) > (_pageWidth * 0.5f)) {
         _currentOffset = _scrollView.contentOffset.x;
     }
 

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -23,6 +23,9 @@
 #import "TOPagingViewAnimator.h"
 #import <QuartzCore/QuartzCore.h>
 
+/// Mark implementation-only methods as being statically called to increase performance.
+#define TOPAGINGVIEWANIMATOR_OBJC_DIRECT __attribute__((objc_direct))
+
 // -----------------------------------------------------------------
 
 /// Default duration for page turn animations.
@@ -91,13 +94,16 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 @interface TOPagingViewAnimator ()
 
+- (void)_createDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+- (void)_destroyDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT;
+
 /// The display link driving the frame-by-frame animation.
 @property (nonatomic, strong, nullable) CADisplayLink *displayLink;
 
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// The direction we're turning in
+/// The direction we're turning in.
 @property (nonatomic, assign, readwrite) UIRectEdge direction;
 
 /// The direction multiplier (+1 for right, -1 for left).
@@ -195,11 +201,13 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
     if (_turnDirection != dir) { return; }
-    
+
+    // Clamp the remaining travel to the centered slot once we know there are no more pages.
     _endOffset = _pageWidth;
 }
 
-- (void)didTransitionWithOffset:(CGFloat)offset {
+- (void)didTransitionWithOffset:(CGFloat)offset
+{
     if (!_isAnimating) { return; }
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, scale);
@@ -226,7 +234,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 #pragma mark - Display Link -
 
-- (void)_createDisplayLink
+- (void)_createDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT
 {
     _displayLink = [CADisplayLink displayLinkWithTarget:self
                                               selector:@selector(_displayLinkDidFire:)];
@@ -239,7 +247,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
                        forMode:NSRunLoopCommonModes];
 }
 
-- (void)_destroyDisplayLink
+- (void)_destroyDisplayLink TOPAGINGVIEWANIMATOR_OBJC_DIRECT
 {
     [_displayLink invalidate];
     _displayLink = nil;

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -36,11 +36,17 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 /// The time at which the current animation cycle started (reset on each tap).
 @property (nonatomic, assign) CFTimeInterval startTime;
 
-/// The starting content offset X for the current animation.
-@property (nonatomic, assign) CGFloat startOffsetX;
+/// The direction multiplier (+1 for right, -1 for left).
+@property (nonatomic, assign) CGFloat turnDirection;
 
-/// The destination content offset X for the current animation.
-@property (nonatomic, assign) CGFloat targetOffsetX;
+/// The animated distance at the start of the current easing cycle.
+@property (nonatomic, assign) CGFloat startDistance;
+
+/// The total target distance for the current animation sequence.
+@property (nonatomic, assign) CGFloat endDistance;
+
+/// The amount of distance already applied to the scroll view.
+@property (nonatomic, assign) CGFloat currentDistance;
 
 @end
 
@@ -69,13 +75,25 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
 - (void)turnToPageInDirection:(UIRectEdge)direction
 {
     UIScrollView *const scrollView = _scrollView;
-    if (scrollView == nil) { return; }
+    if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
+
+    const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+    const CFTimeInterval now = CACurrentMediaTime();
+
+    if (_isAnimating && dir == _turnDirection) {
+        _startDistance = _currentDistance;
+        _endDistance += _pageWidth;
+        _startTime = now;
+        return;
+    }
 
     if (_isAnimating) { [self stopAnimation]; }
 
-    _startOffsetX = scrollView.contentOffset.x;
-    _targetOffsetX = (direction == UIRectEdgeRight) ? (_pageWidth * 2.0f) : 0.0f;
-    _startTime = CACurrentMediaTime();
+    _turnDirection = dir;
+    _startDistance = 0.0f;
+    _currentDistance = 0.0f;
+    _endDistance = _pageWidth;
+    _startTime = now;
     _isAnimating = YES;
     [self _createDisplayLink];
 }
@@ -111,18 +129,31 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
         return;
     }
 
-    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
-    const CGFloat progress = (CGFloat)fmin(elapsed / _duration, 1.0);
-    const CGFloat currentOffset = _startOffsetX + ((_targetOffsetX - _startOffsetX) * progress);
-    scrollView.contentOffset = (CGPoint){currentOffset, 0.0f};
+    const CFTimeInterval now = CACurrentMediaTime();
+    const CGFloat targetDistance = [self _currentAnimatedDistanceAtTime:now];
+    const CGFloat delta = targetDistance - _currentDistance;
+    _currentDistance = targetDistance;
 
-    if (progress >= 1.0f) {
+    CGPoint contentOffset = scrollView.contentOffset;
+    contentOffset.x += delta * _turnDirection;
+    scrollView.contentOffset = contentOffset;
+
+    if (_currentDistance >= _endDistance - FLT_EPSILON) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
         if (_completionHandler) {
             _completionHandler();
         }
     }
+}
+
+#pragma mark - Helpers -
+
+- (CGFloat)_currentAnimatedDistanceAtTime:(CFTimeInterval)time
+{
+    const CFTimeInterval elapsed = time - _startTime;
+    const CGFloat progress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    return _startDistance + ((_endDistance - _startDistance) * progress);
 }
 
 @end

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -26,7 +26,7 @@
 // -----------------------------------------------------------------
 
 /// Default duration for page turn animations.
-static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
+static const CFTimeInterval kTOAnimatorDefaultDuration = 1.4;
 
 @interface TOPagingViewAnimator ()
 
@@ -129,13 +129,20 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
         return;
     }
 
-    const CFTimeInterval now = CACurrentMediaTime();
-    const CGFloat targetDistance = [self _currentAnimatedDistanceAtTime:now];
+    const CFTimeInterval elapsed = CACurrentMediaTime() - _startTime;
+    const CGFloat progress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat targetDistance = _startDistance + ((_endDistance - _startDistance) * progress);
     const CGFloat delta = targetDistance - _currentDistance;
     _currentDistance = targetDistance;
 
+    NSLog(@"delta: %f progress: %f offset: %f", delta, progress, _scrollView.contentOffset.x);
+
     CGPoint contentOffset = scrollView.contentOffset;
-    contentOffset.x += delta * _turnDirection;
+    if (progress < 1.0f - FLT_EPSILON) {
+        contentOffset.x += delta * _turnDirection;
+    } else {
+        contentOffset.x = _scrollView.frame.size.width * 2.0f;
+    }
     scrollView.contentOffset = contentOffset;
 
     if (_currentDistance >= _endDistance - FLT_EPSILON) {
@@ -145,15 +152,6 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.4;
             _completionHandler();
         }
     }
-}
-
-#pragma mark - Helpers -
-
-- (CGFloat)_currentAnimatedDistanceAtTime:(CFTimeInterval)time
-{
-    const CFTimeInterval elapsed = time - _startTime;
-    const CGFloat progress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
-    return _startDistance + ((_endDistance - _startDistance) * progress);
 }
 
 @end

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -123,6 +123,9 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 /// The logical offset from the middle slot where this animation should end.
 @property (nonatomic, assign) CGFloat endOffset;
 
+/// The original scrollEnabled state before this animator temporarily disabled scrolling.
+@property (nonatomic, assign) BOOL originalScrollEnabled;
+
 @end
 
 // -----------------------------------------------------------------
@@ -185,6 +188,8 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
 
     if (!_isAnimating) {
         _isAnimating = YES;
+        _originalScrollEnabled = scrollView.scrollEnabled;
+        scrollView.scrollEnabled = NO;
         [self _createDisplayLink];
     }
 }
@@ -194,6 +199,7 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     if (!_isAnimating) { return; }
     [self _destroyDisplayLink];
     _isAnimating = NO;
+    _scrollView.scrollEnabled = _originalScrollEnabled;
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
@@ -215,6 +221,12 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     _endOffset = TOPagingViewAnimatorClampNearZero(_endOffset, scale);
 
     const CGFloat remainingProgress = 1.0f - progress;
+    if (remainingProgress <= FLT_EPSILON) {
+        _startOffset = actualOffset;
+        _endOffset = actualOffset;
+        return;
+    }
+
     _startOffset = (actualOffset - (_endOffset * progress)) / remainingProgress;
     _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset, scale);
     _startOffset = TOPagingViewAnimatorSnapToPageBoundary(_startOffset, _pageWidth, scale);
@@ -255,13 +267,13 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
     scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorAbsoluteOffset(targetOffset, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)), 0.0f};
-    NSLog(@"target %f, scroll offset: %f", targetOffset, scrollView.contentOffset.x);
     
     const CGFloat pixelSize = 1.0f / TOPagingViewAnimatorDisplayScale(scrollView);
     if (progress >= 1.0f - FLT_EPSILON
         && fabs(TOPagingViewAnimatorLogicalOffset(scrollView.contentOffset.x, _pageWidth, TOPagingViewAnimatorDisplayScale(scrollView)) - _endOffset) <= pixelSize) {
         [self _destroyDisplayLink];
         _isAnimating = NO;
+        _scrollView.scrollEnabled = _originalScrollEnabled;
         if (_completionHandler) {
             _completionHandler();
         }

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -208,10 +208,23 @@ static inline CGFloat TOPagingViewAnimatorAbsoluteOffset(CGFloat logicalOffset, 
     return (_turnDirection != dir);
 }
 
-- (void)stopAnimationInDirection:(UIRectEdge)direction {
+- (BOOL)stopAnimationInDirection:(UIRectEdge)direction {
     const CGFloat dir = (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
-    if (_turnDirection != dir) { return; }
-    [self stopAnimation];
+    if (!_isAnimating || _turnDirection != dir) { return NO; }
+
+    const CGFloat scale = TOPagingViewAnimatorDisplayScale(_scrollView);
+    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
+                                                         : (CACurrentMediaTime() - _startTime);
+    const CGFloat linearProgress = (_duration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin(elapsed / _duration, 1.0);
+    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+
+    const CGFloat remainingProgress = 1.0f - progress;
+    if (remainingProgress <= FLT_EPSILON) {
+        [self stopAnimation];
+        return YES;
+    }
+
+    return NO;
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {

--- a/TOPagingView/TOPagingViewAnimator.m
+++ b/TOPagingView/TOPagingViewAnimator.m
@@ -102,14 +102,24 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 }
 
 /// Returns the active simulator animation drag coefficient when Slow Animations is enabled.
-static inline CFTimeInterval TOPagingViewAnimatorEffectiveDuration(CFTimeInterval duration) {
+static inline CGFloat TOPagingViewAnimatorAnimationDragCoefficient(void) {
 #if TARGET_OS_SIMULATOR
     extern float UIAnimationDragCoefficient(void) __attribute__((weak_import));
     const float dragCoefficient = (UIAnimationDragCoefficient != NULL) ? UIAnimationDragCoefficient() : 1.0f;
-    return duration * ((dragCoefficient > FLT_EPSILON) ? dragCoefficient : 1.0f);
+    return (dragCoefficient > FLT_EPSILON) ? dragCoefficient : 1.0f;
 #else
-    return duration;
+    return 1.0f;
 #endif
+}
+
+/// Returns the active simulator animation drag coefficient when Slow Animations is enabled.
+static inline CFTimeInterval TOPagingViewAnimatorEffectiveDuration(CFTimeInterval duration) {
+    return duration * TOPagingViewAnimatorAnimationDragCoefficient();
+}
+
+/// Converts a wall-clock duration back into the animator's base duration space.
+static inline CFTimeInterval TOPagingViewAnimatorBaseDuration(CFTimeInterval effectiveDuration) {
+    return effectiveDuration / TOPagingViewAnimatorAnimationDragCoefficient();
 }
 
 /// Converts elapsed time into clamped linear animation progress.
@@ -120,8 +130,7 @@ static inline CGFloat TOPagingViewAnimatorLinearProgress(CFTimeInterval elapsed,
 
 /// Clamps a duration into the short settle window used when an in-flight turn is cut short.
 static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInterval duration) {
-    const CFTimeInterval maxDuration = fmin(duration, 0.22);
-    return fmax(0.08, maxDuration);
+    return fmax(0.05, duration);
 }
 
 // -----------------------------------------------------------------
@@ -246,9 +255,10 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     const CGFloat scale = TOPagingViewAnimatorDisplayScale(scrollView);
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, scale);
     const CFTimeInterval now = CACurrentMediaTime();
-    const CFTimeInterval elapsed = (_displayLink != nil) ? (_displayLink.targetTimestamp - _startTime)
-                                                         : (now - _startTime);
+    const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
+    const CFTimeInterval elapsed = referenceTime - _startTime;
     const CGFloat linearProgress = TOPagingViewAnimatorLinearProgress(elapsed, _activeDuration);
+    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     const CGFloat easingSlope = TOPagingViewAnimatorEvaluateEasingSlope(linearProgress);
     const CFTimeInterval effectiveDuration = TOPagingViewAnimatorEffectiveDuration(_activeDuration);
     const CGFloat currentVelocity = (effectiveDuration <= FLT_EPSILON)
@@ -256,24 +266,42 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
         : (((_endOffset - _startOffset) * easingSlope) / effectiveDuration);
     const CGFloat remainingDistance = _pageWidth - actualOffset;
 
-    // Re-seed the in-flight segment from the live on-screen position so clamping doesn't jump.
-    _startOffset = actualOffset;
-    _endOffset = _pageWidth;
-    _startTime = now;
-
     const CGFloat velocityTowardTarget = currentVelocity * ((remainingDistance >= 0.0f) ? 1.0f : -1.0f);
     if (fabs(remainingDistance) <= (1.0f / fmax(scale, 1.0f))) {
+        _startOffset = actualOffset;
+        _endOffset = _pageWidth;
+        _startTime = referenceTime;
         _activeDuration = 0.0;
         return;
     }
 
-    if (velocityTowardTarget > FLT_EPSILON) {
-        const CGFloat startSlope = fmax(TOPagingViewAnimatorEvaluateEasingSlope(0.0f), 1.0f);
-        const CFTimeInterval settleDuration = (fabs(remainingDistance) * startSlope) / velocityTowardTarget;
-        _activeDuration = TOPagingViewAnimatorClampSettleDuration(settleDuration);
-    } else {
-        _activeDuration = TOPagingViewAnimatorClampSettleDuration(_duration * 0.45);
+    const CGFloat remainingProgress = 1.0f - progress;
+    if (velocityTowardTarget > FLT_EPSILON
+        && remainingProgress > FLT_EPSILON
+        && easingSlope > FLT_EPSILON) {
+        // Preserve the current easing phase so the clamp continues smoothly instead of restarting.
+        CGFloat syntheticStartOffset = (actualOffset - (_pageWidth * progress)) / remainingProgress;
+        syntheticStartOffset = TOPagingViewAnimatorRoundToPixel(syntheticStartOffset, scale);
+
+        const CGFloat totalDistance = _pageWidth - syntheticStartOffset;
+        if (fabs(totalDistance) > FLT_EPSILON
+            && ((totalDistance >= 0.0f) == (remainingDistance >= 0.0f))) {
+            const CFTimeInterval effectiveSettleDuration = (fabs(totalDistance) * easingSlope) / velocityTowardTarget;
+            const CFTimeInterval baseSettleDuration = TOPagingViewAnimatorClampSettleDuration(TOPagingViewAnimatorBaseDuration(effectiveSettleDuration));
+            const CFTimeInterval adjustedEffectiveDuration = TOPagingViewAnimatorEffectiveDuration(baseSettleDuration);
+
+            _startOffset = syntheticStartOffset;
+            _endOffset = _pageWidth;
+            _startTime = referenceTime - (linearProgress * adjustedEffectiveDuration);
+            _activeDuration = baseSettleDuration;
+            return;
+        }
     }
+
+    _startOffset = actualOffset;
+    _endOffset = _pageWidth;
+    _startTime = referenceTime;
+    _activeDuration = TOPagingViewAnimatorClampSettleDuration(_duration * 0.45);
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset

--- a/TOPagingViewExample/TOTestPageView.m
+++ b/TOPagingViewExample/TOTestPageView.m
@@ -23,6 +23,7 @@
         self.backgroundColor = [UIColor redColor];
         
         self.numberLabel = [[UILabel alloc] initWithFrame:(CGRect){0,0,320,128}];
+        self.numberLabel.accessibilityIdentifier = @"page_number_label";
         self.numberLabel.textColor = [UIColor whiteColor];
         self.numberLabel.font = [UIFont boldSystemFontOfSize:100.0f];
         self.numberLabel.textAlignment = NSTextAlignmentCenter;

--- a/TOPagingViewExample/TOViewController.m
+++ b/TOPagingViewExample/TOViewController.m
@@ -48,10 +48,6 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
 - (TOTestPageView *)pagingView:(TOPagingView *)pagingView
                                   pageViewForType:(TOPagingViewPageType)type
                                   currentPageView:(TOTestPageView *)currentPageView {
-    if (self.pageIndex >= 5) {
-        return nil;
-    }
-
     TOTestPageView *pageView = [pagingView dequeueReusablePageView];
 
     switch (type) {

--- a/TOPagingViewExample/TOViewController.m
+++ b/TOPagingViewExample/TOViewController.m
@@ -10,7 +10,10 @@
 #import "TOPagingView.h"
 #import "TOTestPageView.h"
 
-@interface TOViewController () <TOPagingViewDataSource, TOPagingViewDelegate>
+static NSString *const kTOPagingViewAccessibilityIdentifier = @"paging_view";
+static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_button";
+
+@interface TOViewController () <TOPagingViewDataSource, TOPagingViewDelegate, UIScrollViewDelegate>
 
 // Current page state tracking
 @property (nonatomic, assign) NSInteger pageIndex;
@@ -22,6 +25,23 @@
 @end
 
 @implementation TOViewController
+
+#pragma mark - Accessibility -
+
+- (void)updatePagingViewAccessibilityState
+{
+    if (self.pagingView == nil) { return; }
+
+    const CGFloat pageWidth = CGRectGetWidth(self.pagingView.bounds) + self.pagingView.pageSpacing;
+    CGFloat offsetError = self.pagingView.scrollView.contentOffset.x - pageWidth;
+    if (fabs(offsetError) < 0.0005f) {
+        offsetError = 0.0f;
+    }
+
+    self.pagingView.accessibilityValue = [NSString stringWithFormat:@"page=%ld;offset=%.3f",
+                                          (long)self.pageIndex,
+                                          offsetError];
+}
 
 #pragma mark - Paging View Data Source -
 
@@ -64,6 +84,7 @@
     if (type == TOPagingViewPageTypeNext) { _pageIndex++; }
     if (type == TOPagingViewPageTypePrevious) { _pageIndex--; }
 
+    [self updatePagingViewAccessibilityState];
     NSLog(@"Paging view did turn to: %@ at page %ld", [self stringForType:type], (long)self.pageIndex);
 }
 
@@ -100,6 +121,18 @@
     }
 }
 
+#pragma mark - UIScrollViewDelegate -
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    [self updatePagingViewAccessibilityState];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    [self updatePagingViewAccessibilityState];
+}
+
 #pragma mark - View Controller Lifecycle -
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -122,6 +155,9 @@
     //self.pagingView.isDynamicPageDirectionEnabled = YES;
     self.pagingView.dataSource = self;
     self.pagingView.delegate = self;
+    self.pagingView.scrollViewDelegate = self;
+    self.pagingView.isAccessibilityElement = YES;
+    self.pagingView.accessibilityIdentifier = kTOPagingViewAccessibilityIdentifier;
     [self.pagingView registerPageViewClass:TOTestPageView.class];
     self.pagingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:self.pagingView];
@@ -142,8 +178,17 @@
     button.frame = (CGRect){0,0,100,50};
     button.center = (CGPoint){CGRectGetMidX(self.pagingView.frame), CGRectGetHeight(self.pagingView.frame) - 50};
     button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
+    button.accessibilityIdentifier = kTODirectionButtonAccessibilityIdentifier;
     [self.view addSubview:button];
     self.button = button;
+
+    [self updatePagingViewAccessibilityState];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    [self updatePagingViewAccessibilityState];
 }
 
 - (void)buttonTapped {

--- a/TOPagingViewExample/TOViewController.m
+++ b/TOPagingViewExample/TOViewController.m
@@ -48,6 +48,10 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
 - (TOTestPageView *)pagingView:(TOPagingView *)pagingView
                                   pageViewForType:(TOPagingViewPageType)type
                                   currentPageView:(TOTestPageView *)currentPageView {
+    if (self.pageIndex >= 5) {
+        return nil;
+    }
+
     TOTestPageView *pageView = [pagingView dequeueReusablePageView];
 
     switch (type) {

--- a/TOPagingViewUITests/Info.plist
+++ b/TOPagingViewUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TOPagingViewUITests/TOPagingViewUITests.m
+++ b/TOPagingViewUITests/TOPagingViewUITests.m
@@ -1,0 +1,95 @@
+//
+//  TOPagingViewUITests.m
+//  TOPagingViewUITests
+//
+//  Created by Codex on 2026/03/24.
+//
+
+#import <XCTest/XCTest.h>
+
+static NSString *const kTOPagingViewAccessibilityIdentifier = @"paging_view";
+
+@interface TOPagingViewUITests : XCTestCase
+@property (nonatomic, strong) XCUIApplication *app;
+@end
+
+@implementation TOPagingViewUITests
+
+- (void)setUp
+{
+    [super setUp];
+    self.continueAfterFailure = NO;
+
+    self.app = [[XCUIApplication alloc] init];
+    [self.app launch];
+
+    [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationLandscapeRight];
+}
+
+- (nullable NSDictionary<NSString *, NSNumber *> *)pagingStateForElement:(XCUIElement *)pagingView
+{
+    id rawValue = pagingView.value;
+    if (![rawValue isKindOfClass:NSString.class]) { return nil; }
+
+    NSString *value = (NSString *)rawValue;
+    NSArray<NSString *> *components = [value componentsSeparatedByString:@";"];
+    if (components.count < 2) { return nil; }
+
+    NSInteger page = NSNotFound;
+    CGFloat offset = CGFLOAT_MAX;
+
+    for (NSString *component in components) {
+        NSArray<NSString *> *parts = [component componentsSeparatedByString:@"="];
+        if (parts.count != 2) { continue; }
+
+        NSString *key = parts.firstObject;
+        NSString *stringValue = parts.lastObject;
+        if ([key isEqualToString:@"page"]) {
+            page = stringValue.integerValue;
+        } else if ([key isEqualToString:@"offset"]) {
+            offset = (CGFloat)stringValue.doubleValue;
+        }
+    }
+
+    if (page == NSNotFound || offset == CGFLOAT_MAX) { return nil; }
+    return @{@"page": @(page), @"offset": @(offset)};
+}
+
+- (BOOL)waitForPagingView:(XCUIElement *)pagingView
+            toReachPage:(NSInteger)page
+        maxOffsetError:(CGFloat)maxOffsetError
+                timeout:(NSTimeInterval)timeout
+{
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+
+    while (deadline.timeIntervalSinceNow > 0.0) {
+        NSDictionary<NSString *, NSNumber *> *state = [self pagingStateForElement:pagingView];
+        if (state != nil) {
+            const NSInteger currentPage = state[@"page"].integerValue;
+            const CGFloat offset = state[@"offset"].doubleValue;
+            if (currentPage == page && fabs(offset) <= maxOffsetError) {
+                return YES;
+            }
+        }
+
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    return NO;
+}
+
+- (void)testRapidRightTapsLandOnExpectedPageInLandscape
+{
+    XCUIElement *pagingView = self.app.otherElements[kTOPagingViewAccessibilityIdentifier];
+    XCTAssertTrue([pagingView waitForExistenceWithTimeout:5.0]);
+
+    XCUICoordinate *rightTapCoordinate = [pagingView coordinateWithNormalizedOffset:CGVectorMake(0.9, 0.5)];
+    for (NSInteger i = 0; i < 10; i++) {
+        [rightTapCoordinate tap];
+    }
+
+    XCTAssertTrue([self waitForPagingView:pagingView toReachPage:10 maxOffsetError:0.5f timeout:5.0],
+                  @"Final paging state was %@", pagingView.value);
+}
+
+@end

--- a/TOPagingViewUITests/TOPagingViewUITests.m
+++ b/TOPagingViewUITests/TOPagingViewUITests.m
@@ -78,6 +78,27 @@ static NSString *const kTOPagingViewAccessibilityIdentifier = @"paging_view";
     return NO;
 }
 
+- (BOOL)waitForPagingView:(XCUIElement *)pagingView
+    toExceedOffsetError:(CGFloat)minimumOffsetError
+                timeout:(NSTimeInterval)timeout
+{
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+
+    while (deadline.timeIntervalSinceNow > 0.0) {
+        NSDictionary<NSString *, NSNumber *> *state = [self pagingStateForElement:pagingView];
+        if (state != nil) {
+            const CGFloat offset = state[@"offset"].doubleValue;
+            if (fabs(offset) >= minimumOffsetError) {
+                return YES;
+            }
+        }
+
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    return NO;
+}
+
 - (void)testRapidRightTapsLandOnExpectedPageInLandscape
 {
     XCUIElement *pagingView = self.app.otherElements[kTOPagingViewAccessibilityIdentifier];
@@ -90,6 +111,25 @@ static NSString *const kTOPagingViewAccessibilityIdentifier = @"paging_view";
 
     XCTAssertTrue([self waitForPagingView:pagingView toReachPage:10 maxOffsetError:0.5f timeout:5.0],
                   @"Final paging state was %@", pagingView.value);
+}
+
+- (void)testDraggingMidAnimationCancelsProgrammaticTurnAndHandsOffToPaging
+{
+    XCUIElement *pagingView = self.app.otherElements[kTOPagingViewAccessibilityIdentifier];
+    XCTAssertTrue([pagingView waitForExistenceWithTimeout:5.0]);
+
+    XCUICoordinate *rightTapCoordinate = [pagingView coordinateWithNormalizedOffset:CGVectorMake(0.9, 0.5)];
+    [rightTapCoordinate tap];
+
+    XCTAssertTrue([self waitForPagingView:pagingView toExceedOffsetError:20.0f timeout:1.0],
+                  @"Paging view never moved far enough off center. State was %@", pagingView.value);
+
+    XCUICoordinate *dragStart = [pagingView coordinateWithNormalizedOffset:CGVectorMake(0.35, 0.5)];
+    XCUICoordinate *dragEnd = [pagingView coordinateWithNormalizedOffset:CGVectorMake(0.95, 0.5)];
+    [dragStart pressForDuration:0.05 thenDragToCoordinate:dragEnd];
+
+    XCTAssertTrue([self waitForPagingView:pagingView toReachPage:0 maxOffsetError:0.5f timeout:5.0],
+                  @"Final paging state after drag handoff was %@", pagingView.value);
 }
 
 @end


### PR DESCRIPTION
The original page-turning code path was a really naive one, set up as a static, pre-canned animation. This unfortunately meant if the user interrupted the animation to start a new one, it was necessary to immediately cancel the animation, reset the state, and then animate again. This resulted in a very visible snap that was quite jarring.

This PR refactors the entire system to do it dynamically instead. Tapping the screen results in adding a velocity that then stacks as more taps are added. This then fluidly advances to the appropriate page on a bicubic decceleration curve.

I want to call out here that I was using both Claude and Codex here, and while they were useful for the very superficial coding tasks like implementing the timing functions, they ended up being only about 20% of the whole process. This feature required an incredibly deep knowledge of `UIScrollView` and its constraints (Things like how `contentOffset` enforces pixel clamping, and that controlling `contentOffset` doesn't work properly when `pagingEnabled` is `YES`) in order to perfect.

| Before | After |
| --- | --- |
| ![](https://github.com/user-attachments/assets/0bceba6e-860a-4b3b-9837-db60b0ee6636) | ![](https://github.com/user-attachments/assets/eb65c7bb-1f66-4aaf-b0b4-d061937b5f59) |