### PR TITLE
Rebuild the edge collision animation at the last page

### DIFF
--- a/TOPagingView/Internal/TOPagingViewAnimator.h
+++ b/TOPagingView/Internal/TOPagingViewAnimator.h
@@ -57,6 +57,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
+/// When YES, the in-flight animation passes any offset past the rest position (`pageWidth`)
+/// in the direction of motion through UIScrollView's rubber-band formula. The bezier's velocity
+/// at the crossing drives how far the visible offset stretches, with a soft asymptote one page
+/// wide so the page never scrolls fully into the void. Cleared on stop and on a fresh-direction
+/// turn so a reversal isn't resisted.
+@property (nonatomic, assign) BOOL rubberBandsAtRest;
+
 /// Animates toward the next page in the given direction.
 /// @param direction The edge to turn toward (UIRectEdgeLeft or UIRectEdgeRight).
 - (void)turnToPageInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT;
@@ -69,10 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// were offset by one page segment. We pass that segment delta here so the
 /// animator can rebase its absolute content offset targets.
 - (void)didTransitionWithOffset:(CGFloat)offset TOPAGINGVIEW_OBJC_DIRECT;
-
-/// Called when we've detected we're in animation run and we're about to hit the outer boundary of pages.
-/// This method modifies the current velocity so it gracefully decelerates to the boundary instead.
-- (void)clampAnimationToOffset:(CGFloat)targetOffset TOPAGINGVIEW_OBJC_DIRECT;
 
 /// Returns a pointer to the animator's live state struct. The pointer's lifetime matches the animator's.
 /// Callers may cache it and read fields directly to avoid per-tick ObjC property accessors.

--- a/TOPagingView/Internal/TOPagingViewAnimator.h
+++ b/TOPagingView/Internal/TOPagingViewAnimator.h
@@ -60,7 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// When YES, the moment the in-flight bezier crosses the rest position the animator hands off
 /// to a critically damped spring whose initial velocity matches the bezier. The spring continues
 /// past briefly, peaks, and decays back to rest as one continuous motion. Cleared on stop and
-/// on a fresh-direction turn so a reversal isn't resisted.
+/// on direction reversal — same-direction taps during settle keep the flag armed so each tap
+/// re-energises the spring rather than getting absorbed.
 @property (nonatomic, assign) BOOL rubberBandsAtRest;
 
 /// Animates toward the next page in the given direction.

--- a/TOPagingView/Internal/TOPagingViewAnimator.h
+++ b/TOPagingView/Internal/TOPagingViewAnimator.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Must be set before calling `turnToPageInDirection:`.
 @property (nonatomic, assign) CGFloat pageWidth;
 
-/// The duration of each animation cycle in seconds (default 0.4).
+/// The duration of each animation cycle in seconds (default 0.5).
 @property (nonatomic, assign) CFTimeInterval duration;
 
 /// Whether an animation is currently in progress.
@@ -57,11 +57,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// Called when the animation completes naturally (not when stopped mid-way).
 @property (nonatomic, copy, nullable) void (^completionHandler)(void);
 
-/// When YES, the in-flight animation passes any offset past the rest position (`pageWidth`)
-/// in the direction of motion through UIScrollView's rubber-band formula. The bezier's velocity
-/// at the crossing drives how far the visible offset stretches, with a soft asymptote one page
-/// wide so the page never scrolls fully into the void. Cleared on stop and on a fresh-direction
-/// turn so a reversal isn't resisted.
+/// When YES, the moment the in-flight bezier crosses the rest position the animator hands off
+/// to a critically damped spring whose initial velocity matches the bezier. The spring continues
+/// past briefly, peaks, and decays back to rest as one continuous motion. Cleared on stop and
+/// on a fresh-direction turn so a reversal isn't resisted.
 @property (nonatomic, assign) BOOL rubberBandsAtRest;
 
 /// Animates toward the next page in the given direction.

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -40,7 +40,6 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
 /// the duration once visible motion is sub-pixel.
 static const CGFloat kTOAnimatorRubberBandSpringMass            = 1.0f;
 static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 300.0f;
-static const CGFloat kTOAnimatorRubberBandSpringDampingRatio    = 1.0f;
 static const CGFloat kTOAnimatorRubberBandSpringSettleThreshold = 0.5f;
 
 /// Cubic bezier control points for the ease-out curve.
@@ -51,9 +50,7 @@ static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
 
 // -----------------------------------------------------------------
 
-/// Evaluates a cubic bezier easing curve for the given linear time progress.
-/// @param t Linear time progress from 0.0 to 1.0.
-/// @return Eased progress from 0.0 to 1.0.
+/// Cubic bezier ease-out: solves for u where x(u) = t (Newton), then returns y(u).
 static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
     CGFloat u = t;
     for (int i = 0; i < 8; i++) {
@@ -72,7 +69,7 @@ static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
            u * u * u;
 }
 
-/// Snaps a value to the nearest page boundary only when already within one pixel of that boundary.
+/// Snaps to the nearest page boundary if within one pixel.
 static inline CGFloat TOPagingViewAnimatorSnapToPageBoundary(CGFloat value, CGFloat pageWidth, CGFloat scale) {
     if (pageWidth <= FLT_EPSILON) { return value; }
     const CGFloat nearestPageBoundary = round(value / pageWidth) * pageWidth;
@@ -81,33 +78,145 @@ static inline CGFloat TOPagingViewAnimatorSnapToPageBoundary(CGFloat value, CGFl
     return value;
 }
 
-/// Fetches the reference time of the current animation, derived from the CADisplayLink's time if available, or CACurrentMediaTime otherwise.
+/// Reference time for the current frame: the displayLink's targetTimestamp if available,
+/// otherwise wall-clock now.
 static inline CFTimeInterval TOPagingViewAnimatorReferenceTime(CADisplayLink *_Nullable displayLink) {
     return (displayLink != nil) ? displayLink.targetTimestamp : CACurrentMediaTime();
 }
 
-/// Rounds a value to the nearest screen pixel for the given display scale.
+/// Rounds to the nearest screen pixel for the given display scale.
 static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat scale) {
     NSCAssert(scale > 0, @"Display scale must be positive.");
     return round(value * scale) / scale;
 }
 
+// =================================================================
+// MARK: - Timing Parameters
+// =================================================================
+
+/// 1-D timing source. `valueAtTime:` returns the offset at time t (relative to the parameters'
+/// own start). `duration` is the wall-clock window after which the parameters are considered
+/// complete and the animator should stop.
+@protocol TOPagingViewTimingParameters <NSObject>
+@property (nonatomic, readonly) CFTimeInterval duration;
+- (CGFloat)valueAtTime:(CFTimeInterval)t;
+@end
+
+// -- Bezier ease-out --
+
+@interface TOPagingViewBezierTimingParameters : NSObject <TOPagingViewTimingParameters>
+@property (nonatomic, readonly) CGFloat startOffset;
+@property (nonatomic, readonly) CGFloat endOffset;
++ (instancetype)timingParametersWithStartOffset:(CGFloat)startOffset
+                                       endOffset:(CGFloat)endOffset
+                                        duration:(CFTimeInterval)duration TOPAGINGVIEW_OBJC_DIRECT;
+/// Wall-clock velocity (pts/sec) at time t — sampled finite-difference of the easing curve.
+- (CGFloat)velocityAtTime:(CFTimeInterval)t TOPAGINGVIEW_OBJC_DIRECT;
+@end
+
+@implementation TOPagingViewBezierTimingParameters {
+    CGFloat _startOffset;
+    CGFloat _endOffset;
+    CFTimeInterval _duration;
+}
+
+@synthesize duration = _duration;
+@synthesize startOffset = _startOffset;
+@synthesize endOffset = _endOffset;
+
++ (instancetype)timingParametersWithStartOffset:(CGFloat)startOffset
+                                       endOffset:(CGFloat)endOffset
+                                        duration:(CFTimeInterval)duration {
+    TOPagingViewBezierTimingParameters *p = [self new];
+    p->_startOffset = startOffset;
+    p->_endOffset = endOffset;
+    p->_duration = duration;
+    return p;
+}
+
+- (CGFloat)valueAtTime:(CFTimeInterval)t {
+    if (_duration <= FLT_EPSILON) { return _endOffset; }
+    const CGFloat linearProgress = (CGFloat)fmin(t / _duration, 1.0);
+    return _startOffset + (_endOffset - _startOffset) * TOPagingViewAnimatorEvaluateEasing(linearProgress);
+}
+
+- (CGFloat)velocityAtTime:(CFTimeInterval)t {
+    if (_duration <= FLT_EPSILON) { return 0.0f; }
+    const CGFloat linearProgress = (CGFloat)fmin(t / _duration, 1.0);
+    const CGFloat slopeDelta = (CGFloat)1e-3;
+    const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
+    const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
+    const CGFloat dxSpan = tA - tB;
+    if (dxSpan <= FLT_EPSILON) { return 0.0f; }
+    const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
+    return (_endOffset - _startOffset) * (dySpan / dxSpan) / (CGFloat)_duration;
+}
+
+@end
+
+// -- Critically damped spring --
+
+@interface TOPagingViewSpringTimingParameters : NSObject <TOPagingViewTimingParameters>
++ (instancetype)timingParametersWithRestOffset:(CGFloat)restOffset
+                                    displacement:(CGFloat)displacement
+                                        velocity:(CGFloat)velocity
+                                            mass:(CGFloat)mass
+                                       stiffness:(CGFloat)stiffness
+                                       threshold:(CGFloat)threshold TOPAGINGVIEW_OBJC_DIRECT;
+@end
+
+@implementation TOPagingViewSpringTimingParameters {
+    CGFloat _restOffset;
+    CGFloat _beta;
+    CGFloat _c1;
+    CGFloat _c2;
+    CFTimeInterval _duration;
+}
+
+@synthesize duration = _duration;
+
++ (instancetype)timingParametersWithRestOffset:(CGFloat)restOffset
+                                    displacement:(CGFloat)displacement
+                                        velocity:(CGFloat)velocity
+                                            mass:(CGFloat)mass
+                                       stiffness:(CGFloat)stiffness
+                                       threshold:(CGFloat)threshold {
+    TOPagingViewSpringTimingParameters *p = [self new];
+    const CGFloat beta = (CGFloat)sqrt(stiffness / mass); // critical damping (ζ = 1)
+    p->_restOffset = restOffset;
+    p->_beta = beta;
+    p->_c1 = displacement;
+    p->_c2 = velocity + beta * displacement;
+
+    // Settle time: per-component upper bound (max of when each part falls below threshold).
+    // Components already under the threshold contribute 0.
+    const CFTimeInterval t1 = (fabs(p->_c1) > threshold * 0.5f)
+        ? (1.0 / beta) * log(2.0 * fabs(p->_c1) / threshold) : 0.0;
+    const CFTimeInterval t2 = (fabs(p->_c2) > (CGFloat)M_E * beta * threshold * 0.25f)
+        ? (2.0 / beta) * log(4.0 * fabs(p->_c2) / ((CGFloat)M_E * beta * threshold)) : 0.0;
+    p->_duration = fmax(0.0, fmax(t1, t2));
+    return p;
+}
+
+- (CGFloat)valueAtTime:(CFTimeInterval)t {
+    if (t >= _duration) { return _restOffset; }
+    return _restOffset + (CGFloat)(exp(-_beta * t) * (_c1 + _c2 * t));
+}
+
+@end
+
+// =================================================================
+// MARK: - Animator
+// =================================================================
+
 @implementation TOPagingViewAnimator {
-    CADisplayLink *_displayLink;            /// The display link driving the frame-by-frame animation.
-    CFTimeInterval _startTime;              /// The time at which the current animation segment started.
-    CFTimeInterval _activeEffectiveDuration; /// The duration of the current segment after applying any active simulator drag coefficient.
-    CGFloat _directionMultiplier;           /// The direction multiplier (+1 for right, -1 for left).
-    CGFloat _startOffset;                   /// The absolute scroll view content offset when we started.
-    CGFloat _endOffset;                     /// The absolute scroll view content offset where this animation should end.
-    BOOL _originalPagingEnabled;            /// The original pagingEnabled state before this animator temporarily disabled paging.
-    BOOL _isInSpringSettle;                 /// YES while the rubber-band spring drives contentOffset.
-    CFTimeInterval _springStartTime;        /// Wall-clock when the spring took over from the bezier.
-    CFTimeInterval _springDuration;         /// Analytical settle time for the current spring state.
-    CGFloat _springBeta;                    /// damping / (2·mass) — exponential decay rate.
-    CGFloat _springC1;                      /// Initial displacement past the rest boundary.
-    CGFloat _springC2;                      /// = initialVelocity + β·displacement (closed-form coefficient).
-    TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached environment values that stay stable for the life of an animation.
-    TOPagingViewAnimatorState _state;       /// Live state exposed via -statePointer so the paging view can read it without msg sends.
+    CADisplayLink *_displayLink;            /// Drives valueAtTime: each frame onto the scroll view.
+    CFTimeInterval _activeStartTime;        /// Wall-clock when _activeTiming was installed.
+    id<TOPagingViewTimingParameters> _activeTiming; /// Current bezier or spring source.
+    CGFloat _directionMultiplier;           /// +1 right, −1 left.
+    BOOL _originalPagingEnabled;            /// Pre-animation pagingEnabled, restored on stop.
+    TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached display scale + slow-animation drag coefficient.
+    TOPagingViewAnimatorState _state;       /// Live state pointer-readable by the paging view.
 }
 
 #pragma mark - Object Lifecycle -
@@ -117,7 +226,6 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (self) {
         _duration = kTOAnimatorDefaultDuration;
         _environmentMetrics = (TOPagingViewAnimatorEnvironmentMetrics){.displayScale = 1.0f, .pixelSize = 1.0f, .animationDragCoefficient = 1.0f};
-        _activeEffectiveDuration = kTOAnimatorDefaultDuration;
     }
     return self;
 }
@@ -146,39 +254,36 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
     const CFTimeInterval now = CACurrentMediaTime();
     const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
-    
-    // Cache all of the device metrics that won't change in this animation run.
     [self _updateEnvironmentMetrics];
+    const CFTimeInterval segmentDuration = _duration * _environmentMetrics.animationDragCoefficient;
 
-    // If we were already animating, and another turn event comes through, stack it.
+    // Stacking: same-direction tap mid-flight extends the bezier by another page.
     if (_state.isAnimating && dir == _directionMultiplier) {
-        const CGFloat linearProgress = [self _linearProgressAtReferenceTime:referenceTime];
-        const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-        const CGFloat currentOffset =
-            TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress), _environmentMetrics.displayScale);
-        const CGFloat endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset + (dir * _pageWidth), _environmentMetrics.displayScale);
-        [self _configureSegmentWithStartOffset:currentOffset endOffset:endOffset referenceTime:now duration:_duration];
+        TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
+        const CGFloat currentOffset = TOPagingViewAnimatorRoundToPixel([bezier valueAtTime:(referenceTime - _activeStartTime)],
+                                                                       _environmentMetrics.displayScale);
+        const CGFloat newEnd = TOPagingViewAnimatorRoundToPixel(bezier.endOffset + dir * _pageWidth, _environmentMetrics.displayScale);
+        _activeTiming = [TOPagingViewBezierTimingParameters timingParametersWithStartOffset:currentOffset
+                                                                                  endOffset:newEnd
+                                                                                   duration:segmentDuration];
+        _activeStartTime = now;
         return;
     }
 
-    // New direction or fresh start: animate from the current position to the nearest
-    // page boundary in the requested direction. This naturally handles reversal
-    // (tap left while going right snaps back to the page on screen) as well as
-    // re-initiating the original direction mid-reversal without drift.
+    // Fresh direction (or fresh start). Reversal drops any rubber-band state.
     _state.direction = pageDirection;
     _directionMultiplier = dir;
-    // Reversal drops any rubber-band state; bezier branch picks up from this tick.
     _rubberBandsAtRest = NO;
-    _isInSpringSettle = NO;
+
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
     CGFloat endOffset = (dir > 0.0f) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
                                      : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     endOffset = TOPagingViewAnimatorRoundToPixel(endOffset, _environmentMetrics.displayScale);
-    [self _configureSegmentWithStartOffset:startOffset endOffset:endOffset referenceTime:now duration:_duration];
+    _activeTiming = [TOPagingViewBezierTimingParameters timingParametersWithStartOffset:startOffset
+                                                                              endOffset:endOffset
+                                                                               duration:segmentDuration];
+    _activeStartTime = now;
 
-    // If we weren't already in an animation loop, start the display link.
-    // We also need to disable paging, otherwise our offset code ends up fighting
-    // another display link, internal to UIScrollView that is managing the paging state.
     if (!_state.isAnimating) {
         _state.isAnimating = YES;
         _originalPagingEnabled = scrollView.pagingEnabled;
@@ -189,13 +294,11 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 - (void)stopAnimationWithCompletion:(BOOL)didComplete {
     if (!_state.isAnimating) { return; }
-    // Cancel the display link.
-    // The scroll view will stop at whatever offset it is now.
     [_displayLink invalidate];
     _displayLink = nil;
     _state.isAnimating = NO;
     _rubberBandsAtRest = NO;
-    _isInSpringSettle = NO;
+    _activeTiming = nil;
     _scrollView.pagingEnabled = _originalPagingEnabled;
     if (didComplete && _completionHandler) { _completionHandler(); }
     _completionHandler = nil;
@@ -203,76 +306,35 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
     if (!_state.isAnimating) { return; }
-    
-    // When the paging view performs its transition, which ostensibly just moves all embedded pages either forward or back
-    // by one slot, it is also necessary to apply the same slot distance to our animation start and end positions.
+    if (![_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) { return; }
+
+    // Slot rotation shifted everything by `offset`; rebase the bezier so the visible position
+    // stays continuous through the page transition.
+    TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
     const CGFloat actualOffset = TOPagingViewAnimatorRoundToPixel(_scrollView.contentOffset.x, _environmentMetrics.displayScale);
-    const CFTimeInterval referenceTime = TOPagingViewAnimatorReferenceTime(_displayLink);
-    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:referenceTime];
-    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+    const CFTimeInterval t = TOPagingViewAnimatorReferenceTime(_displayLink) - _activeStartTime;
+    const CGFloat span = bezier.endOffset - bezier.startOffset;
+    const CGFloat progress = (fabs(span) > FLT_EPSILON) ? ([bezier valueAtTime:t] - bezier.startOffset) / span : 1.0f;
 
-    _endOffset += offset;
-    _endOffset = TOPagingViewAnimatorRoundToPixel(_endOffset, _environmentMetrics.displayScale);
-    _endOffset = TOPagingViewAnimatorSnapToPageBoundary(_endOffset, _pageWidth, _environmentMetrics.displayScale);
+    CGFloat newEnd = TOPagingViewAnimatorRoundToPixel(bezier.endOffset + offset, _environmentMetrics.displayScale);
+    newEnd = TOPagingViewAnimatorSnapToPageBoundary(newEnd, _pageWidth, _environmentMetrics.displayScale);
 
-    // If we were effectively at the end already, let's just exit out.
+    CGFloat newStart;
     const CGFloat remainingProgress = 1.0f - progress;
     if (remainingProgress <= FLT_EPSILON) {
-        _startOffset = actualOffset;
-        _endOffset = actualOffset;
-        return;
+        newStart = actualOffset;
+        newEnd = actualOffset;
+    } else {
+        newStart = (actualOffset - (newEnd * progress)) / remainingProgress;
+        newStart = TOPagingViewAnimatorRoundToPixel(newStart, _environmentMetrics.displayScale);
+        newStart = TOPagingViewAnimatorSnapToPageBoundary(newStart, _pageWidth, _environmentMetrics.displayScale);
     }
 
-    _startOffset = (actualOffset - (_endOffset * progress)) / remainingProgress;
-    _startOffset = TOPagingViewAnimatorRoundToPixel(_startOffset, _environmentMetrics.displayScale);
-    _startOffset = TOPagingViewAnimatorSnapToPageBoundary(_startOffset, _pageWidth, _environmentMetrics.displayScale);
-}
-
-#pragma mark - Animation State -
-
-- (void)_updateEnvironmentMetrics TOPAGINGVIEW_OBJC_DIRECT {
-    // Capture device metrics that may change between animations but are stable
-    // enough to cache for the duration of one.
-    
-    // Capture the physical display scale of the screen (eg @2x = 2.0, @3x = 3.0).
-    // `pixelSize` is derived below as its reciprocal.
-    const CGFloat displayScale = ({
-        CGFloat scale = _scrollView.window.screen.scale;
-        if (scale <= FLT_EPSILON) { scale = _scrollView.traitCollection.displayScale; }
-        (scale <= FLT_EPSILON) ? 1.0f : scale;
-    });
-    
-    // When on the simulator, and 'Slow Animations' is enabled, add that coefficient to our animation speed.
-    const CGFloat animationDragCoefficient = ({
-        #if TARGET_OS_SIMULATOR
-            extern float UIAnimationDragCoefficient(void) __attribute__((weak_import));
-            const float dragCoefficient = (UIAnimationDragCoefficient != NULL) ? UIAnimationDragCoefficient() : 1.0f;
-            (dragCoefficient > FLT_EPSILON) ? dragCoefficient : 1.0f;
-        #else
-            1.0f;
-        #endif
-    });
-    
-    // Apply the metrics. These will be regenerated on each new animation run.
-    _environmentMetrics = (TOPagingViewAnimatorEnvironmentMetrics){
-        .displayScale = displayScale,
-        .pixelSize = 1.0f / fmax(displayScale, 1.0f),
-        .animationDragCoefficient = animationDragCoefficient,
-    };
-}
-
-- (CGFloat)_linearProgressAtReferenceTime:(CFTimeInterval)referenceTime TOPAGINGVIEW_OBJC_DIRECT {
-    return (_activeEffectiveDuration <= FLT_EPSILON) ? 1.0f : (CGFloat)fmin((referenceTime - _startTime) / _activeEffectiveDuration, 1.0);
-}
-
-- (void)_configureSegmentWithStartOffset:(CGFloat)startOffset
-                               endOffset:(CGFloat)endOffset
-                           referenceTime:(CFTimeInterval)referenceTime
-                                duration:(CFTimeInterval)duration TOPAGINGVIEW_OBJC_DIRECT {
-    _startOffset = startOffset;
-    _endOffset = endOffset;
-    _startTime = referenceTime;
-    _activeEffectiveDuration = duration * _environmentMetrics.animationDragCoefficient;
+    // Replace the bezier with the rebased version; preserve _activeStartTime so progress is
+    // continuous across the transition.
+    _activeTiming = [TOPagingViewBezierTimingParameters timingParametersWithStartOffset:newStart
+                                                                              endOffset:newEnd
+                                                                               duration:bezier.duration];
 }
 
 #pragma mark - Display Link -
@@ -291,89 +353,65 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     UIScrollView *const scrollView = _scrollView;
     if (scrollView == nil) { [self stopAnimationWithCompletion:NO]; return; }
 
-    if (_isInSpringSettle) { [self _tickRubberBandSpringAtTime:displayLink.targetTimestamp scrollView:scrollView]; return; }
+    const CFTimeInterval now = displayLink.targetTimestamp;
+    const CFTimeInterval t = now - _activeStartTime;
+    const CGFloat value = [_activeTiming valueAtTime:t];
 
-    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
-    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
-    NSCAssert(isfinite(targetOffset), @"Animation target offset must be a finite number, got %f.", targetOffset);
+    // First tick the bezier crosses the rest boundary in rubber-band mode, swap to the spring.
+    if ([self _handOffBezierToSpringIfCrossingBoundaryAtValue:value time:now]) { return; }
 
-    // Hand off to the rubber-band spring the first tick the bezier crosses the rest boundary.
-    if (_rubberBandsAtRest && (_directionMultiplier * (targetOffset - _pageWidth)) > 0.0f) {
-        [self _handOffToRubberBandSpringAtLinearProgress:linearProgress targetOffset:targetOffset
-                                                  atTime:displayLink.targetTimestamp scrollView:scrollView];
-        return;
-    }
-
-    scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
-    if (progress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
-        [self stopAnimationWithCompletion:YES];
-    }
+    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(value, _environmentMetrics.displayScale), 0.0f};
+    if (t >= _activeTiming.duration) { [self stopAnimationWithCompletion:YES]; }
 }
 
 #pragma mark - Rubber-band Spring -
 
-/// Evaluates the closed-form spring at `now` and writes the resulting offset, or settles to rest
-/// once the analytical duration has elapsed.
-- (void)_tickRubberBandSpringAtTime:(CFTimeInterval)now scrollView:(UIScrollView *)scrollView TOPAGINGVIEW_OBJC_DIRECT {
-    const CFTimeInterval t = now - _springStartTime;
-    if (t >= _springDuration) {
-        scrollView.contentOffset = (CGPoint){_pageWidth, 0.0f};
-        _isInSpringSettle = NO;
-        [self stopAnimationWithCompletion:YES];
-        return;
-    }
-    const CGFloat x = (CGFloat)(exp(-_springBeta * t) * (_springC1 + _springC2 * t));
-    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * x,
-                                                                          _environmentMetrics.displayScale), 0.0f};
+/// If the active bezier has just carried the offset past the rest boundary, replace it with a
+/// spring whose v0 matches the bezier's instantaneous velocity. Returns YES if the swap fired.
+- (BOOL)_handOffBezierToSpringIfCrossingBoundaryAtValue:(CGFloat)value time:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
+    if (!_rubberBandsAtRest) { return NO; }
+    if (![_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) { return NO; }
+    if (_directionMultiplier * (value - _pageWidth) <= 0.0f) { return NO; }
+
+    TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
+    const CGFloat velocity = [bezier velocityAtTime:(now - _activeStartTime)];
+    _activeTiming = [TOPagingViewSpringTimingParameters timingParametersWithRestOffset:_pageWidth
+                                                                          displacement:(value - _pageWidth)
+                                                                              velocity:velocity
+                                                                                  mass:kTOAnimatorRubberBandSpringMass
+                                                                             stiffness:kTOAnimatorRubberBandSpringStiffness
+                                                                             threshold:kTOAnimatorRubberBandSpringSettleThreshold];
+    _activeStartTime = now;
+    _scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(value, _environmentMetrics.displayScale), 0.0f};
+    return YES;
 }
 
-/// Recovers the bezier's instantaneous velocity and arms the spring with that as v0, then writes
-/// the t=0 spring value (= overshoot) so the hand-off is continuous.
-- (void)_handOffToRubberBandSpringAtLinearProgress:(CGFloat)linearProgress
-                                       targetOffset:(CGFloat)targetOffset
-                                             atTime:(CFTimeInterval)now
-                                         scrollView:(UIScrollView *)scrollView TOPAGINGVIEW_OBJC_DIRECT {
-    const CGFloat overshoot = _directionMultiplier * (targetOffset - _pageWidth);
-    [self _armRubberBandSpringWithDisplacement:overshoot
-                                       velocity:_directionMultiplier * [self _bezierVelocityAtLinearProgress:linearProgress]
-                                         atTime:now];
-    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * overshoot,
-                                                                          _environmentMetrics.displayScale), 0.0f};
-}
+#pragma mark - Environment -
 
-/// Samples the bezier slope around `linearProgress` and converts to wall-clock pts/sec.
-- (CGFloat)_bezierVelocityAtLinearProgress:(CGFloat)linearProgress TOPAGINGVIEW_OBJC_DIRECT {
-    if (_activeEffectiveDuration <= FLT_EPSILON) { return 0.0f; }
-    const CGFloat slopeDelta = (CGFloat)1e-3;
-    const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
-    const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
-    const CGFloat dxSpan = tA - tB;
-    if (dxSpan <= FLT_EPSILON) { return 0.0f; }
-    const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
-    return (_endOffset - _startOffset) * (dySpan / dxSpan) / (CGFloat)_activeEffectiveDuration;
-}
+- (void)_updateEnvironmentMetrics TOPAGINGVIEW_OBJC_DIRECT {
+    // Display scale (eg @2x = 2.0, @3x = 3.0). pixelSize is the reciprocal.
+    const CGFloat displayScale = ({
+        CGFloat scale = _scrollView.window.screen.scale;
+        if (scale <= FLT_EPSILON) { scale = _scrollView.traitCollection.displayScale; }
+        (scale <= FLT_EPSILON) ? 1.0f : scale;
+    });
 
-/// Sets up x(t) = exp(-β·t)·(c1 + c2·t) and computes its analytical settle duration. v0 is signed
-/// in the direction of motion; positive means "still moving away from rest".
-- (void)_armRubberBandSpringWithDisplacement:(CGFloat)x0 velocity:(CGFloat)v0 atTime:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
-    const CGFloat beta = sqrt(kTOAnimatorRubberBandSpringStiffness / kTOAnimatorRubberBandSpringMass)
-                       * kTOAnimatorRubberBandSpringDampingRatio;
-    _springBeta = beta;
-    _springC1 = x0;
-    _springC2 = v0 + beta * x0;
-    _springStartTime = now;
+    // 'Slow Animations' coefficient on the simulator; 1.0 on device.
+    const CGFloat animationDragCoefficient = ({
+        #if TARGET_OS_SIMULATOR
+            extern float UIAnimationDragCoefficient(void) __attribute__((weak_import));
+            const float dragCoefficient = (UIAnimationDragCoefficient != NULL) ? UIAnimationDragCoefficient() : 1.0f;
+            (dragCoefficient > FLT_EPSILON) ? dragCoefficient : 1.0f;
+        #else
+            1.0f;
+        #endif
+    });
 
-    // Settle time: max of when each closed-form component decays below `threshold`. Components
-    // already under the threshold contribute 0.
-    const CGFloat threshold = kTOAnimatorRubberBandSpringSettleThreshold;
-    const CFTimeInterval t1 = (fabs(_springC1) > threshold * 0.5f)
-        ? (1.0 / beta) * log(2.0 * fabs(_springC1) / threshold) : 0.0;
-    const CFTimeInterval t2 = (fabs(_springC2) > (CGFloat)M_E * beta * threshold * 0.25f)
-        ? (2.0 / beta) * log(4.0 * fabs(_springC2) / ((CGFloat)M_E * beta * threshold)) : 0.0;
-    _springDuration = fmax(0.0, fmax(t1, t2));
-    _isInSpringSettle = YES;
+    _environmentMetrics = (TOPagingViewAnimatorEnvironmentMetrics){
+        .displayScale = displayScale,
+        .pixelSize = 1.0f / fmax(displayScale, 1.0f),
+        .animationDragCoefficient = animationDragCoefficient,
+    };
 }
 
 @end

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -84,11 +84,6 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     return round(value * scale) / scale;
 }
 
-/// Applies the minimum settle window used when an in-flight turn is cut short.
-static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInterval duration) {
-    return fmax(0.05, duration);
-}
-
 @implementation TOPagingViewAnimator {
     CADisplayLink *_displayLink;            /// The display link driving the frame-by-frame animation.
     CFTimeInterval _startTime;              /// The time at which the current animation segment started.
@@ -97,8 +92,6 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     CGFloat _startOffset;                   /// The absolute scroll view content offset when we started.
     CGFloat _endOffset;                     /// The absolute scroll view content offset where this animation should end.
     BOOL _originalPagingEnabled;            /// The original pagingEnabled state before this animator temporarily disabled paging.
-    BOOL _isClampingSegment;                /// Whether the current segment should be evaluated as a velocity-matching cubic Hermite instead of the standard bezier ease-out.
-    CGFloat _clampStartVelocity;            /// Signed wall-clock velocity (points/second) the clamp segment should pick up from. Only meaningful when _isClampingSegment is YES.
     TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached environment values that stay stable for the life of an animation.
     TOPagingViewAnimatorState _state;       /// Live state exposed via -statePointer so the paging view can read it without msg sends.
 }
@@ -156,6 +149,8 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     // re-initiating the original direction mid-reversal without drift.
     _state.direction = pageDirection;
     _directionMultiplier = dir;
+    // Direction change discards any rubber-band-at-rest flag armed for the previous direction.
+    _rubberBandsAtRest = NO;
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
     CGFloat endOffset = (dir > 0.0f) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
                                      : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
@@ -180,66 +175,10 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     [_displayLink invalidate];
     _displayLink = nil;
     _state.isAnimating = NO;
-    _isClampingSegment = NO;
+    _rubberBandsAtRest = NO;
     _scrollView.pagingEnabled = _originalPagingEnabled;
     if (didComplete && _completionHandler) { _completionHandler(); }
     _completionHandler = nil;
-}
-
-- (void)clampAnimationToOffset:(CGFloat)targetOffset {
-    if (!_state.isAnimating) { return; }
-
-    const CFTimeInterval referenceTime = TOPagingViewAnimatorReferenceTime(_displayLink);
-    const CGFloat linearProgress = [self _linearProgressAtReferenceTime:referenceTime];
-    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-
-    // Sample the active segment at its current presentation position so the clamp begins
-    // exactly where the in-flight animation visually is, not at the last whole-frame offset.
-    const CGFloat currentOffset = TOPagingViewAnimatorRoundToPixel(_startOffset + ((_endOffset - _startOffset) * progress),
-                                                                   _environmentMetrics.displayScale);
-    const CGFloat clampedTargetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
-    const CGFloat remainingDistance = clampedTargetOffset - currentOffset;
-
-    // If we're already effectively at the requested target, collapse the segment immediately.
-    if (fabs(remainingDistance) <= _environmentMetrics.pixelSize) {
-        [self _configureSegmentWithStartOffset:currentOffset endOffset:clampedTargetOffset referenceTime:referenceTime duration:0.0];
-        return;
-    }
-
-    // Sample the bezier's instantaneous slope around the current linear progress so the clamp
-    // leg can pick up the in-flight wall-clock velocity. Without this, the Hermite tangent at
-    // t=0 would be zero and we'd see the same velocity discontinuity (visible at slow motion)
-    // that the previous bezier-restart had.
-    CGFloat startVelocity = 0.0f;
-    if (_activeEffectiveDuration > FLT_EPSILON) {
-        const CGFloat slopeDelta = (CGFloat)1e-3;
-        const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
-        const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
-        const CGFloat dxSpan = tA - tB;
-        if (dxSpan > FLT_EPSILON) {
-            const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
-            const CGFloat normalizedSlope = dySpan / dxSpan;
-            startVelocity = (_endOffset - _startOffset) * normalizedSlope / (CGFloat)_activeEffectiveDuration;
-        }
-    }
-
-    // Scale the clamp duration by how much ground is left to cover. A close target gets a
-    // quick settle, a far one gets closer to a full page turn's worth of time, so the curve
-    // plays out at its natural tempo regardless of when the clamp was triggered.
-    const CGFloat distanceRatio = fmin(1.0f, fabs(remainingDistance) / _pageWidth);
-    const CFTimeInterval settleDuration = TOPagingViewAnimatorClampSettleDuration(_duration * distanceRatio);
-
-    [self _configureSegmentWithStartOffset:currentOffset
-                                 endOffset:clampedTargetOffset
-                             referenceTime:referenceTime
-                                  duration:settleDuration];
-
-    // Arm the Hermite leg AFTER the configure call (which clears the flag for the bezier default).
-    // The display link will now interpolate as a cubic Hermite from (currentOffset, startVelocity)
-    // to (clampedTargetOffset, 0), giving C¹ continuity through the clamp instead of cold-starting
-    // an ease-out from rest.
-    _isClampingSegment = YES;
-    _clampStartVelocity = startVelocity;
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
@@ -314,8 +253,6 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     _endOffset = endOffset;
     _startTime = referenceTime;
     _activeEffectiveDuration = duration * _environmentMetrics.animationDragCoefficient;
-    // Default to the bezier path; the clamp call site re-arms the Hermite leg after this returns.
-    _isClampingSegment = NO;
 }
 
 #pragma mark - Display Link -
@@ -338,28 +275,32 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     }
 
     const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
-    CGFloat targetOffset;
-    if (_isClampingSegment) {
-        // Cubic Hermite with H(0)=startOffset, H(1)=endOffset, H'(0)=m0 (matches in-flight velocity),
-        // H'(1)=0 (settle at rest). Tangent is in position-per-unit-t, so convert from points/sec
-        // by multiplying the wall-clock velocity by the segment's wall-clock duration.
-        const CGFloat t = linearProgress;
-        const CGFloat t2 = t * t;
-        const CGFloat t3 = t2 * t;
-        const CGFloat h00 = 2.0f * t3 - 3.0f * t2 + 1.0f;
-        const CGFloat h10 = t3 - 2.0f * t2 + t;
-        const CGFloat h01 = -2.0f * t3 + 3.0f * t2;
-        const CGFloat m0 = _clampStartVelocity * (CGFloat)_activeEffectiveDuration;
-        targetOffset = h00 * _startOffset + h10 * m0 + h01 * _endOffset;
-    } else {
-        const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-        targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
-    }
+    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+    CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
     NSCAssert(isfinite(targetOffset), @"Animation target offset must be a finite number, got %f.", targetOffset);
+
+    // Rubber-band-at-rest: when the data source has flagged that no further page exists in this
+    // direction, pass any offset past the rest position through UIScrollView's standard formula
+    // `b = (1 − 1 / (x·c/d + 1)) · d` (c = 0.55, d = pageWidth). The bezier's velocity at the
+    // crossing drives x, so fast taps stretch further; the formula's asymptote of `d` keeps the
+    // visible travel inside one page width regardless of how aggressive the tap was.
+    if (_rubberBandsAtRest) {
+        const CGFloat overshoot = _directionMultiplier * (targetOffset - _pageWidth);
+        if (overshoot > 0.0f) {
+            const CGFloat resisted = (1.0f - 1.0f / ((overshoot * 0.55f / _pageWidth) + 1.0f)) * _pageWidth;
+            targetOffset = _pageWidth + _directionMultiplier * resisted;
+            targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
+        }
+    }
+
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
 
-    if (linearProgress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
+    // Natural-end: stop once the bezier completes. For the rubber-band case the visible offset
+    // sits at the resisted asymptote rather than `_endOffset`, so the offset-equality check is
+    // bypassed for that path.
+    if (progress >= 1.0f - FLT_EPSILON &&
+        (_rubberBandsAtRest || fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize)) {
         [self stopAnimationWithCompletion:YES];
     }
 }

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -47,6 +47,10 @@ static const CGFloat kTOAnimatorControlPoint1Y = 0.75f;
 static const CGFloat kTOAnimatorControlPoint2X = 0.3f;
 static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
 
+/// Initial dy/dx of the bezier at u=0 — equals (3·CP1Y) / (3·CP1X) = CP1Y/CP1X. Used by the
+/// rubber-band impulse path to reproduce the velocity a fresh bezier-from-rest would impart.
+static const CGFloat kTOAnimatorBezierInitialSlope = kTOAnimatorControlPoint1Y / kTOAnimatorControlPoint1X;
+
 // MARK: - Helpers
 
 /// Cubic bezier ease-out: solves for u where x(u) = t (Newton), then returns y(u).
@@ -165,6 +169,8 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
                                             mass:(CGFloat)mass
                                        stiffness:(CGFloat)stiffness
                                        threshold:(CGFloat)threshold TOPAGINGVIEW_OBJC_DIRECT;
+/// Closed-form velocity at time t: x'(t) = exp(-β·t)·(c2 − β·(c1 + c2·t)).
+- (CGFloat)velocityAtTime:(CFTimeInterval)t TOPAGINGVIEW_OBJC_DIRECT;
 @end
 
 @implementation TOPagingViewSpringTimingParameters {
@@ -203,6 +209,11 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
 - (CGFloat)valueAtTime:(CFTimeInterval)t {
     if (t >= _duration) { return _restOffset; }
     return _restOffset + (CGFloat)(exp(-_beta * t) * (_c1 + _c2 * t));
+}
+
+- (CGFloat)velocityAtTime:(CFTimeInterval)t {
+    if (t >= _duration) { return 0.0f; }
+    return (CGFloat)(exp(-_beta * t) * (_c2 - _beta * (_c1 + _c2 * t)));
 }
 
 @end
@@ -246,17 +257,40 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
     NSAssert(_pageWidth > FLT_EPSILON, @"Page width must be set and positive before starting an animation.");
     if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
 
-    // Discard same-direction taps while the rubber-band is settling; reversal is allowed below.
-    if (_rubberBandsAtRest && pageDirection == _state.direction) { return; }
-
     const CFTimeInterval now = CACurrentMediaTime();
     [self _updateEnvironmentMetrics];
     const CFTimeInterval segmentDuration = _duration * _environmentMetrics.animationDragCoefficient;
 
-    // Stacking: same-direction tap mid-flight extends the active bezier by another page. The
-    // class check guards against an externally-cleared `rubberBandsAtRest` while a spring is
-    // in flight — without it the cast would target a spring and read garbage.
-    if (_state.isAnimating && pageDirection == _state.direction
+    // Same-direction tap during a settling rubber-band: kick the spring with another impulse
+    // rather than swapping to a fresh bezier (which would stall a frame on the bezier→spring
+    // handoff before any visible movement). Position stays continuous, velocity gets the same
+    // boost a fresh bezier-from-rest would impart, so each tap visibly punts the offset
+    // further out before the spring pulls it back.
+    if (_state.isAnimating && pageDirection == _state.direction && _rubberBandsAtRest
+        && [_activeTiming isKindOfClass:[TOPagingViewSpringTimingParameters class]]) {
+        TOPagingViewSpringTimingParameters *const oldSpring = (TOPagingViewSpringTimingParameters *)_activeTiming;
+        const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
+        const CFTimeInterval elapsed = referenceTime - _activeStartTime;
+        const CGFloat currentValue = [oldSpring valueAtTime:elapsed];
+        const CGFloat currentVelocity = [oldSpring velocityAtTime:elapsed];
+        // Impulse magnitude matches a fresh bezier-from-rest's initial velocity:
+        // span * slopeAtStart / duration, with span = _pageWidth.
+        const CGFloat dir = TOPagingViewAnimatorDirectionMultiplier(pageDirection);
+        const CGFloat impulse = dir * _pageWidth * kTOAnimatorBezierInitialSlope / (CGFloat)segmentDuration;
+        _activeTiming = [TOPagingViewSpringTimingParameters timingParametersWithRestOffset:_pageWidth
+                                                                              displacement:(currentValue - _pageWidth)
+                                                                                  velocity:(currentVelocity + impulse)
+                                                                                      mass:kTOAnimatorRubberBandSpringMass
+                                                                                 stiffness:kTOAnimatorRubberBandSpringStiffness
+                                                                                 threshold:kTOAnimatorRubberBandSpringSettleThreshold];
+        _activeStartTime = referenceTime;
+        return;
+    }
+
+    // Stacking: same-direction tap mid-flight extends the active bezier by another page. Only
+    // valid for normal page chains while the active timing is still a bezier — rubber-band
+    // taps go through the impulse branch above instead.
+    if (_state.isAnimating && pageDirection == _state.direction && !_rubberBandsAtRest
         && [_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) {
         TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
         const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
@@ -271,9 +305,11 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
         return;
     }
 
-    // Fresh direction (or fresh start). Reversal drops any rubber-band state.
+    // Reversal drops any in-flight rubber-band so a back-tap isn't resisted. A same-direction
+    // tap during a settling spring keeps the flag armed: the impulse branch above re-energises
+    // it without resetting the trajectory.
+    if (pageDirection != _state.direction) { _rubberBandsAtRest = NO; }
     _state.direction = pageDirection;
-    _rubberBandsAtRest = NO;
 
     // Target the page boundary one full page past where natural decel would settle: round
     // startOffset to the nearest boundary (its decel rest), then advance one page in tap dir.

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -275,9 +275,12 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
     _state.direction = pageDirection;
     _rubberBandsAtRest = NO;
 
+    // Target the page boundary one full page past where natural decel would settle: round
+    // startOffset to the nearest boundary (its decel rest), then advance one page in tap dir.
+    // This way a tap mid-decel always adds a full page beyond what the swipe would have done.
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
-    CGFloat endOffset = (pageDirection == UIRectEdgeRight) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
-                                                           : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
+    const CGFloat nearestRest = round(startOffset / _pageWidth) * _pageWidth;
+    CGFloat endOffset = nearestRest + TOPagingViewAnimatorDirectionMultiplier(pageDirection) * _pageWidth;
     endOffset = TOPagingViewAnimatorRoundToPixel(endOffset, _environmentMetrics.displayScale);
     _activeTiming = [TOPagingViewBezierTimingParameters timingParametersWithStartOffset:startOffset
                                                                               endOffset:endOffset

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -371,6 +371,9 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
 
 /// If the active bezier has just carried the offset past the rest boundary, replace it with a
 /// spring whose v0 matches the bezier's instantaneous velocity. Returns YES if the swap fired.
+/// Assumes the rest position is `_pageWidth` (the middle slot), which is true for every site
+/// that arms `rubberBandsAtRest` today — the flag is only set when an adjacent-page fetch
+/// returns nil while the current page is centered.
 - (BOOL)_handOffBezierToSpringIfCrossingBoundaryAtValue:(CGFloat)value time:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
     if (!_rubberBandsAtRest) { return NO; }
     if (![_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) { return NO; }

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -35,11 +35,10 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
 
-/// Critically damped rubber-band spring. Closed-form x(t) = exp(-β·t)·(c1 + c2·t) per
-/// ScrollMechanics' SpringTimingParameters. Higher stiffness = snappier; settleThreshold caps
-/// the duration once visible motion is sub-pixel.
+/// Critically damped rubber-band spring. Closed-form x(t) = exp(-β·t)·(c1 + c2·t)
+/// Higher stiffness = snappier; settleThreshold caps the duration once visible motion is sub-pixel.
 static const CGFloat kTOAnimatorRubberBandSpringMass            = 1.0f;
-static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 300.0f;
+static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 250.0f;
 static const CGFloat kTOAnimatorRubberBandSpringSettleThreshold = 0.5f;
 
 /// Cubic bezier control points for the ease-out curve.

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -30,7 +30,7 @@
 #import "TOPagingViewTypes.h"
 #import "TOPagingViewTypesPrivate.h"
 
-// -----------------------------------------------------------------
+// MARK: - Constants
 
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
@@ -47,7 +47,7 @@ static const CGFloat kTOAnimatorControlPoint1Y = 0.75f;
 static const CGFloat kTOAnimatorControlPoint2X = 0.3f;
 static const CGFloat kTOAnimatorControlPoint2Y = 1.0f;
 
-// -----------------------------------------------------------------
+// MARK: - Helpers
 
 /// Cubic bezier ease-out: solves for u where x(u) = t (Newton), then returns y(u).
 static inline CGFloat TOPagingViewAnimatorEvaluateEasing(CGFloat t) {
@@ -89,9 +89,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     return round(value * scale) / scale;
 }
 
-// =================================================================
+/// +1 for right, −1 for left. Centralizes the direction-to-multiplier conversion.
+static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge direction) {
+    return (direction == UIRectEdgeRight) ? 1.0f : -1.0f;
+}
+
 // MARK: - Timing Parameters
-// =================================================================
 
 /// 1-D timing source. `valueAtTime:` returns the offset at time t (relative to the parameters'
 /// own start). `duration` is the wall-clock window after which the parameters are considered
@@ -119,9 +122,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     CFTimeInterval _duration;
 }
 
+// `duration` only comes from the protocol so it needs an explicit synthesize; the other two
+// auto-synthesize from their @interface declarations.
 @synthesize duration = _duration;
-@synthesize startOffset = _startOffset;
-@synthesize endOffset = _endOffset;
 
 + (instancetype)timingParametersWithStartOffset:(CGFloat)startOffset
                                        endOffset:(CGFloat)endOffset
@@ -204,15 +207,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 @end
 
-// =================================================================
 // MARK: - Animator
-// =================================================================
 
 @implementation TOPagingViewAnimator {
     CADisplayLink *_displayLink;            /// Drives valueAtTime: each frame onto the scroll view.
     CFTimeInterval _activeStartTime;        /// Wall-clock when _activeTiming was installed.
     id<TOPagingViewTimingParameters> _activeTiming; /// Current bezier or spring source.
-    CGFloat _directionMultiplier;           /// +1 right, −1 left.
     BOOL _originalPagingEnabled;            /// Pre-animation pagingEnabled, restored on stop.
     TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached display scale + slow-animation drag coefficient.
     TOPagingViewAnimatorState _state;       /// Live state pointer-readable by the paging view.
@@ -246,19 +246,21 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     NSAssert(_pageWidth > FLT_EPSILON, @"Page width must be set and positive before starting an animation.");
     if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
 
-    const CGFloat dir = (pageDirection == UIRectEdgeRight) ? 1.0f : -1.0f;
-
     // Discard same-direction taps while the rubber-band is settling; reversal is allowed below.
-    if (_rubberBandsAtRest && dir == _directionMultiplier) { return; }
+    if (_rubberBandsAtRest && pageDirection == _state.direction) { return; }
 
     const CFTimeInterval now = CACurrentMediaTime();
-    const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
     [self _updateEnvironmentMetrics];
     const CFTimeInterval segmentDuration = _duration * _environmentMetrics.animationDragCoefficient;
 
-    // Stacking: same-direction tap mid-flight extends the bezier by another page.
-    if (_state.isAnimating && dir == _directionMultiplier) {
+    // Stacking: same-direction tap mid-flight extends the active bezier by another page. The
+    // class check guards against an externally-cleared `rubberBandsAtRest` while a spring is
+    // in flight — without it the cast would target a spring and read garbage.
+    if (_state.isAnimating && pageDirection == _state.direction
+        && [_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) {
         TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
+        const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
+        const CGFloat dir = TOPagingViewAnimatorDirectionMultiplier(pageDirection);
         const CGFloat currentOffset = TOPagingViewAnimatorRoundToPixel([bezier valueAtTime:(referenceTime - _activeStartTime)],
                                                                        _environmentMetrics.displayScale);
         const CGFloat newEnd = TOPagingViewAnimatorRoundToPixel(bezier.endOffset + dir * _pageWidth, _environmentMetrics.displayScale);
@@ -271,12 +273,11 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
     // Fresh direction (or fresh start). Reversal drops any rubber-band state.
     _state.direction = pageDirection;
-    _directionMultiplier = dir;
     _rubberBandsAtRest = NO;
 
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
-    CGFloat endOffset = (dir > 0.0f) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
-                                     : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
+    CGFloat endOffset = (pageDirection == UIRectEdgeRight) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
+                                                           : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
     endOffset = TOPagingViewAnimatorRoundToPixel(endOffset, _environmentMetrics.displayScale);
     _activeTiming = [TOPagingViewBezierTimingParameters timingParametersWithStartOffset:startOffset
                                                                               endOffset:endOffset
@@ -370,7 +371,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 - (BOOL)_handOffBezierToSpringIfCrossingBoundaryAtValue:(CGFloat)value time:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
     if (!_rubberBandsAtRest) { return NO; }
     if (![_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) { return NO; }
-    if (_directionMultiplier * (value - _pageWidth) <= 0.0f) { return NO; }
+    if (TOPagingViewAnimatorDirectionMultiplier(_state.direction) * (value - _pageWidth) <= 0.0f) { return NO; }
 
     TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
     const CGFloat velocity = [bezier velocityAtTime:(now - _activeStartTime)];

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -35,6 +35,21 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
 
+/// Critically damped spring that takes over from the bezier the moment the offset crosses the
+/// rest boundary in rubber-band mode. Picks up the bezier's velocity as v0; the spring's natural
+/// motion then carries the offset past the boundary, peaks, and decays back to rest as one
+/// continuous solution. Modeled on https://github.com/super-ultra/ScrollMechanics
+/// (SpringTimingParameters.swift): for damping ratio 1, x(t) = exp(-β·t)·(c1 + c2·t), where
+/// β = damping/(2·mass), c1 = displacement, c2 = velocity + β·displacement.
+///
+/// Higher stiffness = faster oscillation (shorter overshoot peak time, shorter overall settle).
+/// `settleThreshold` is the visible-position threshold below which the spring is considered
+/// finished — sub-pixel motion isn't perceptible, so we stop ticking past that.
+static const CGFloat kTOAnimatorRubberBandSpringMass         = 1.0f;
+static const CGFloat kTOAnimatorRubberBandSpringStiffness    = 300.0f;
+static const CGFloat kTOAnimatorRubberBandSpringDampingRatio = 1.0f;
+static const CGFloat kTOAnimatorRubberBandSpringSettleThreshold = 0.5f;
+
 /// Cubic bezier control points for the ease-out curve.
 static const CGFloat kTOAnimatorControlPoint1X = 0.35f;
 static const CGFloat kTOAnimatorControlPoint1Y = 0.75f;
@@ -92,6 +107,16 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     CGFloat _startOffset;                   /// The absolute scroll view content offset when we started.
     CGFloat _endOffset;                     /// The absolute scroll view content offset where this animation should end.
     BOOL _originalPagingEnabled;            /// The original pagingEnabled state before this animator temporarily disabled paging.
+
+    /// Spring physics state — armed when the bezier crosses the rubber-band boundary, drives
+    /// contentOffset until the analytical settle duration elapses.
+    BOOL _isInSpringSettle;
+    CFTimeInterval _springStartTime;
+    CFTimeInterval _springDuration;
+    CGFloat _springBeta;                    /// damping / (2·mass) — exponential decay rate.
+    CGFloat _springC1;                      /// = initial displacement past the rest boundary.
+    CGFloat _springC2;                      /// = initial velocity + β·displacement (per the closed-form solution).
+
     TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached environment values that stay stable for the life of an animation.
     TOPagingViewAnimatorState _state;       /// Live state exposed via -statePointer so the paging view can read it without msg sends.
 }
@@ -126,6 +151,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     if (scrollView == nil || _pageWidth <= FLT_EPSILON) { return; }
 
     const CGFloat dir = (pageDirection == UIRectEdgeRight) ? 1.0f : -1.0f;
+
+    // While the rubber-band sequence is in flight, discard further turns in the same direction —
+    // the user has exhausted travel that way and must wait for the snap-back to settle. A turn
+    // in the opposite direction is allowed and will cancel the snap-back below.
+    if (_rubberBandsAtRest && dir == _directionMultiplier) { return; }
+
     const CFTimeInterval now = CACurrentMediaTime();
     const CFTimeInterval referenceTime = (_displayLink != nil) ? _displayLink.targetTimestamp : now;
     
@@ -149,8 +180,10 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     // re-initiating the original direction mid-reversal without drift.
     _state.direction = pageDirection;
     _directionMultiplier = dir;
-    // Direction change discards any rubber-band-at-rest flag armed for the previous direction.
+    // Direction change discards any rubber-band state from the previous direction. The spring
+    // phase, if any, just stops being driven — the bezier branch takes over from this tick.
     _rubberBandsAtRest = NO;
+    _isInSpringSettle = NO;
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
     CGFloat endOffset = (dir > 0.0f) ? ceil(startOffset / _pageWidth + FLT_EPSILON) * _pageWidth
                                      : floor(startOffset / _pageWidth - FLT_EPSILON) * _pageWidth;
@@ -176,6 +209,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     _displayLink = nil;
     _state.isAnimating = NO;
     _rubberBandsAtRest = NO;
+    _isInSpringSettle = NO;
     _scrollView.pagingEnabled = _originalPagingEnabled;
     if (didComplete && _completionHandler) { _completionHandler(); }
     _completionHandler = nil;
@@ -274,35 +308,103 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
         return;
     }
 
+    // Spring phase: closed-form critical-damped oscillator drives contentOffset until it settles
+    // at the rest boundary. x(t) = exp(-β·t)·(c1 + c2·t) gives the signed displacement past the
+    // boundary in the direction of motion; absolute offset = pageWidth + sign · x.
+    if (_isInSpringSettle) {
+        const CFTimeInterval t = displayLink.targetTimestamp - _springStartTime;
+        if (t >= _springDuration) {
+            scrollView.contentOffset = (CGPoint){_pageWidth, 0.0f};
+            _isInSpringSettle = NO;
+            [self stopAnimationWithCompletion:YES];
+            return;
+        }
+        const CGFloat x = (CGFloat)(exp(-_springBeta * t) * (_springC1 + _springC2 * t));
+        const CGFloat absoluteOffset = TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * x,
+                                                                         _environmentMetrics.displayScale);
+        scrollView.contentOffset = (CGPoint){absoluteOffset, 0.0f};
+        return;
+    }
+
     const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
     CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
     NSCAssert(isfinite(targetOffset), @"Animation target offset must be a finite number, got %f.", targetOffset);
 
-    // Rubber-band-at-rest: when the data source has flagged that no further page exists in this
-    // direction, pass any offset past the rest position through UIScrollView's standard formula
-    // `b = (1 − 1 / (x·c/d + 1)) · d` (c = 0.55, d = pageWidth). The bezier's velocity at the
-    // crossing drives x, so fast taps stretch further; the formula's asymptote of `d` keeps the
-    // visible travel inside one page width regardless of how aggressive the tap was.
+    // Rubber-band hand-off: when the bezier first carries the offset past the rest boundary in
+    // rubber-band mode, recover its instantaneous velocity and pass it as v0 to a critically
+    // damped spring. The spring then takes over — its natural motion handles the overshoot peak
+    // and the snap-back as one continuous solution, matching SpringTimingParameters' approach.
     if (_rubberBandsAtRest) {
         const CGFloat overshoot = _directionMultiplier * (targetOffset - _pageWidth);
         if (overshoot > 0.0f) {
-            const CGFloat resisted = (1.0f - 1.0f / ((overshoot * 0.55f / _pageWidth) + 1.0f)) * _pageWidth;
-            targetOffset = _pageWidth + _directionMultiplier * resisted;
-            targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
+            CGFloat absVelocity = 0.0f;
+            if (_activeEffectiveDuration > FLT_EPSILON) {
+                const CGFloat slopeDelta = (CGFloat)1e-3;
+                const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
+                const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
+                const CGFloat dxSpan = tA - tB;
+                if (dxSpan > FLT_EPSILON) {
+                    const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
+                    const CGFloat slope = dySpan / dxSpan;
+                    absVelocity = (_endOffset - _startOffset) * slope / (CGFloat)_activeEffectiveDuration;
+                }
+            }
+            const CGFloat signedVelocityIntoVoid = _directionMultiplier * absVelocity;
+            [self _startRubberBandSpringFromDisplacement:overshoot
+                                                velocity:signedVelocityIntoVoid
+                                                  atTime:displayLink.targetTimestamp];
+            // Apply this tick's spring value (which equals overshoot at t=0) so position is
+            // continuous through the hand-off; subsequent ticks fall into the spring branch.
+            const CGFloat absoluteOffset = TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * overshoot,
+                                                                             _environmentMetrics.displayScale);
+            scrollView.contentOffset = (CGPoint){absoluteOffset, 0.0f};
+            return;
         }
     }
 
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
 
-    // Natural-end: stop once the bezier completes. For the rubber-band case the visible offset
-    // sits at the resisted asymptote rather than `_endOffset`, so the offset-equality check is
-    // bypassed for that path.
-    if (progress >= 1.0f - FLT_EPSILON &&
-        (_rubberBandsAtRest || fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize)) {
+    // Natural-end for the regular bezier path. The rubber-band path can't reach here because
+    // it always exits via the spring hand-off above before the bezier completes.
+    if (progress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
         [self stopAnimationWithCompletion:YES];
     }
+}
+
+- (void)_startRubberBandSpringFromDisplacement:(CGFloat)x0
+                                        velocity:(CGFloat)v0
+                                          atTime:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
+    // Critical damping: damping = 2·dampingRatio·sqrt(mass·stiffness), β = damping / (2·mass).
+    // For the closed-form solution x(t) = exp(-β·t)·(c1 + c2·t), c1 is the initial displacement
+    // and c2 is initialVelocity + β·displacement. v0 here is signed in the direction of motion,
+    // so positive means "still moving away from the rest position" — the spring then naturally
+    // continues past, peaks, and decays back toward 0.
+    const CGFloat damping = 2.0f * kTOAnimatorRubberBandSpringDampingRatio
+                                 * sqrt(kTOAnimatorRubberBandSpringMass * kTOAnimatorRubberBandSpringStiffness);
+    const CGFloat beta = damping / (2.0f * kTOAnimatorRubberBandSpringMass);
+
+    _springBeta = beta;
+    _springC1 = x0;
+    _springC2 = v0 + beta * x0;
+    _springStartTime = now;
+
+    // Analytical settle duration (per ScrollMechanics' SpringTimingParameters): max of the times
+    // each component falls below the visible-motion threshold. If a component is already below
+    // the threshold (negative log argument) treat its contribution as zero.
+    const CGFloat threshold = kTOAnimatorRubberBandSpringSettleThreshold;
+    CFTimeInterval t1 = 0.0;
+    if (fabs(_springC1) > threshold * 0.5f) {
+        t1 = (1.0 / beta) * log(2.0 * fabs(_springC1) / threshold);
+    }
+    CFTimeInterval t2 = 0.0;
+    const CGFloat c2_lower_bound = (CGFloat)(M_E) * beta * threshold * 0.25f;
+    if (fabs(_springC2) > c2_lower_bound) {
+        t2 = (2.0 / beta) * log(4.0 * fabs(_springC2) / ((CGFloat)(M_E) * beta * threshold));
+    }
+    _springDuration = fmax(0.0, fmax(t1, t2));
+    _isInSpringSettle = YES;
 }
 
 @end

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -97,6 +97,8 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     CGFloat _startOffset;                   /// The absolute scroll view content offset when we started.
     CGFloat _endOffset;                     /// The absolute scroll view content offset where this animation should end.
     BOOL _originalPagingEnabled;            /// The original pagingEnabled state before this animator temporarily disabled paging.
+    BOOL _isClampingSegment;                /// Whether the current segment should be evaluated as a velocity-matching cubic Hermite instead of the standard bezier ease-out.
+    CGFloat _clampStartVelocity;            /// Signed wall-clock velocity (points/second) the clamp segment should pick up from. Only meaningful when _isClampingSegment is YES.
     TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached environment values that stay stable for the life of an animation.
     TOPagingViewAnimatorState _state;       /// Live state exposed via -statePointer so the paging view can read it without msg sends.
 }
@@ -178,6 +180,7 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     [_displayLink invalidate];
     _displayLink = nil;
     _state.isAnimating = NO;
+    _isClampingSegment = NO;
     _scrollView.pagingEnabled = _originalPagingEnabled;
     if (didComplete && _completionHandler) { _completionHandler(); }
     _completionHandler = nil;
@@ -203,9 +206,26 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
         return;
     }
 
+    // Sample the bezier's instantaneous slope around the current linear progress so the clamp
+    // leg can pick up the in-flight wall-clock velocity. Without this, the Hermite tangent at
+    // t=0 would be zero and we'd see the same velocity discontinuity (visible at slow motion)
+    // that the previous bezier-restart had.
+    CGFloat startVelocity = 0.0f;
+    if (_activeEffectiveDuration > FLT_EPSILON) {
+        const CGFloat slopeDelta = (CGFloat)1e-3;
+        const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
+        const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
+        const CGFloat dxSpan = tA - tB;
+        if (dxSpan > FLT_EPSILON) {
+            const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
+            const CGFloat normalizedSlope = dySpan / dxSpan;
+            startVelocity = (_endOffset - _startOffset) * normalizedSlope / (CGFloat)_activeEffectiveDuration;
+        }
+    }
+
     // Scale the clamp duration by how much ground is left to cover. A close target gets a
-    // quick settle, a far one gets closer to a full page turn's worth of time, so the ease-out
-    // curve always plays out at its natural tempo regardless of the current animation's state.
+    // quick settle, a far one gets closer to a full page turn's worth of time, so the curve
+    // plays out at its natural tempo regardless of when the clamp was triggered.
     const CGFloat distanceRatio = fmin(1.0f, fabs(remainingDistance) / _pageWidth);
     const CFTimeInterval settleDuration = TOPagingViewAnimatorClampSettleDuration(_duration * distanceRatio);
 
@@ -213,6 +233,13 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
                                  endOffset:clampedTargetOffset
                              referenceTime:referenceTime
                                   duration:settleDuration];
+
+    // Arm the Hermite leg AFTER the configure call (which clears the flag for the bezier default).
+    // The display link will now interpolate as a cubic Hermite from (currentOffset, startVelocity)
+    // to (clampedTargetOffset, 0), giving C¹ continuity through the clamp instead of cold-starting
+    // an ease-out from rest.
+    _isClampingSegment = YES;
+    _clampStartVelocity = startVelocity;
 }
 
 - (void)didTransitionWithOffset:(CGFloat)offset {
@@ -287,6 +314,8 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     _endOffset = endOffset;
     _startTime = referenceTime;
     _activeEffectiveDuration = duration * _environmentMetrics.animationDragCoefficient;
+    // Default to the bezier path; the clamp call site re-arms the Hermite leg after this returns.
+    _isClampingSegment = NO;
 }
 
 #pragma mark - Display Link -
@@ -309,13 +338,28 @@ static inline CFTimeInterval TOPagingViewAnimatorClampSettleDuration(CFTimeInter
     }
 
     const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
-    const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
-    CGFloat targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
+    CGFloat targetOffset;
+    if (_isClampingSegment) {
+        // Cubic Hermite with H(0)=startOffset, H(1)=endOffset, H'(0)=m0 (matches in-flight velocity),
+        // H'(1)=0 (settle at rest). Tangent is in position-per-unit-t, so convert from points/sec
+        // by multiplying the wall-clock velocity by the segment's wall-clock duration.
+        const CGFloat t = linearProgress;
+        const CGFloat t2 = t * t;
+        const CGFloat t3 = t2 * t;
+        const CGFloat h00 = 2.0f * t3 - 3.0f * t2 + 1.0f;
+        const CGFloat h10 = t3 - 2.0f * t2 + t;
+        const CGFloat h01 = -2.0f * t3 + 3.0f * t2;
+        const CGFloat m0 = _clampStartVelocity * (CGFloat)_activeEffectiveDuration;
+        targetOffset = h00 * _startOffset + h10 * m0 + h01 * _endOffset;
+    } else {
+        const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
+        targetOffset = _startOffset + ((_endOffset - _startOffset) * progress);
+    }
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
     NSCAssert(isfinite(targetOffset), @"Animation target offset must be a finite number, got %f.", targetOffset);
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
 
-    if (progress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
+    if (linearProgress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
         [self stopAnimationWithCompletion:YES];
     }
 }

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -35,19 +35,12 @@
 /// Default duration for page turn animations.
 static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
 
-/// Critically damped spring that takes over from the bezier the moment the offset crosses the
-/// rest boundary in rubber-band mode. Picks up the bezier's velocity as v0; the spring's natural
-/// motion then carries the offset past the boundary, peaks, and decays back to rest as one
-/// continuous solution. Modeled on https://github.com/super-ultra/ScrollMechanics
-/// (SpringTimingParameters.swift): for damping ratio 1, x(t) = exp(-β·t)·(c1 + c2·t), where
-/// β = damping/(2·mass), c1 = displacement, c2 = velocity + β·displacement.
-///
-/// Higher stiffness = faster oscillation (shorter overshoot peak time, shorter overall settle).
-/// `settleThreshold` is the visible-position threshold below which the spring is considered
-/// finished — sub-pixel motion isn't perceptible, so we stop ticking past that.
-static const CGFloat kTOAnimatorRubberBandSpringMass         = 1.0f;
-static const CGFloat kTOAnimatorRubberBandSpringStiffness    = 300.0f;
-static const CGFloat kTOAnimatorRubberBandSpringDampingRatio = 1.0f;
+/// Critically damped rubber-band spring. Closed-form x(t) = exp(-β·t)·(c1 + c2·t) per
+/// ScrollMechanics' SpringTimingParameters. Higher stiffness = snappier; settleThreshold caps
+/// the duration once visible motion is sub-pixel.
+static const CGFloat kTOAnimatorRubberBandSpringMass            = 1.0f;
+static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 300.0f;
+static const CGFloat kTOAnimatorRubberBandSpringDampingRatio    = 1.0f;
 static const CGFloat kTOAnimatorRubberBandSpringSettleThreshold = 0.5f;
 
 /// Cubic bezier control points for the ease-out curve.
@@ -107,16 +100,12 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     CGFloat _startOffset;                   /// The absolute scroll view content offset when we started.
     CGFloat _endOffset;                     /// The absolute scroll view content offset where this animation should end.
     BOOL _originalPagingEnabled;            /// The original pagingEnabled state before this animator temporarily disabled paging.
-
-    /// Spring physics state — armed when the bezier crosses the rubber-band boundary, drives
-    /// contentOffset until the analytical settle duration elapses.
-    BOOL _isInSpringSettle;
-    CFTimeInterval _springStartTime;
-    CFTimeInterval _springDuration;
+    BOOL _isInSpringSettle;                 /// YES while the rubber-band spring drives contentOffset.
+    CFTimeInterval _springStartTime;        /// Wall-clock when the spring took over from the bezier.
+    CFTimeInterval _springDuration;         /// Analytical settle time for the current spring state.
     CGFloat _springBeta;                    /// damping / (2·mass) — exponential decay rate.
-    CGFloat _springC1;                      /// = initial displacement past the rest boundary.
-    CGFloat _springC2;                      /// = initial velocity + β·displacement (per the closed-form solution).
-
+    CGFloat _springC1;                      /// Initial displacement past the rest boundary.
+    CGFloat _springC2;                      /// = initialVelocity + β·displacement (closed-form coefficient).
     TOPagingViewAnimatorEnvironmentMetrics _environmentMetrics; /// Cached environment values that stay stable for the life of an animation.
     TOPagingViewAnimatorState _state;       /// Live state exposed via -statePointer so the paging view can read it without msg sends.
 }
@@ -152,9 +141,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
     const CGFloat dir = (pageDirection == UIRectEdgeRight) ? 1.0f : -1.0f;
 
-    // While the rubber-band sequence is in flight, discard further turns in the same direction —
-    // the user has exhausted travel that way and must wait for the snap-back to settle. A turn
-    // in the opposite direction is allowed and will cancel the snap-back below.
+    // Discard same-direction taps while the rubber-band is settling; reversal is allowed below.
     if (_rubberBandsAtRest && dir == _directionMultiplier) { return; }
 
     const CFTimeInterval now = CACurrentMediaTime();
@@ -180,8 +167,7 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     // re-initiating the original direction mid-reversal without drift.
     _state.direction = pageDirection;
     _directionMultiplier = dir;
-    // Direction change discards any rubber-band state from the previous direction. The spring
-    // phase, if any, just stops being driven — the bezier branch takes over from this tick.
+    // Reversal drops any rubber-band state; bezier branch picks up from this tick.
     _rubberBandsAtRest = NO;
     _isInSpringSettle = NO;
     const CGFloat startOffset = TOPagingViewAnimatorRoundToPixel(scrollView.contentOffset.x, _environmentMetrics.displayScale);
@@ -303,28 +289,9 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
 
 - (void)_displayLinkDidFire:(CADisplayLink *)displayLink {
     UIScrollView *const scrollView = _scrollView;
-    if (scrollView == nil) {
-        [self stopAnimationWithCompletion:NO];
-        return;
-    }
+    if (scrollView == nil) { [self stopAnimationWithCompletion:NO]; return; }
 
-    // Spring phase: closed-form critical-damped oscillator drives contentOffset until it settles
-    // at the rest boundary. x(t) = exp(-β·t)·(c1 + c2·t) gives the signed displacement past the
-    // boundary in the direction of motion; absolute offset = pageWidth + sign · x.
-    if (_isInSpringSettle) {
-        const CFTimeInterval t = displayLink.targetTimestamp - _springStartTime;
-        if (t >= _springDuration) {
-            scrollView.contentOffset = (CGPoint){_pageWidth, 0.0f};
-            _isInSpringSettle = NO;
-            [self stopAnimationWithCompletion:YES];
-            return;
-        }
-        const CGFloat x = (CGFloat)(exp(-_springBeta * t) * (_springC1 + _springC2 * t));
-        const CGFloat absoluteOffset = TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * x,
-                                                                         _environmentMetrics.displayScale);
-        scrollView.contentOffset = (CGPoint){absoluteOffset, 0.0f};
-        return;
-    }
+    if (_isInSpringSettle) { [self _tickRubberBandSpringAtTime:displayLink.targetTimestamp scrollView:scrollView]; return; }
 
     const CGFloat linearProgress = [self _linearProgressAtReferenceTime:displayLink.targetTimestamp];
     const CGFloat progress = TOPagingViewAnimatorEvaluateEasing(linearProgress);
@@ -332,77 +299,79 @@ static inline CGFloat TOPagingViewAnimatorRoundToPixel(CGFloat value, CGFloat sc
     targetOffset = TOPagingViewAnimatorRoundToPixel(targetOffset, _environmentMetrics.displayScale);
     NSCAssert(isfinite(targetOffset), @"Animation target offset must be a finite number, got %f.", targetOffset);
 
-    // Rubber-band hand-off: when the bezier first carries the offset past the rest boundary in
-    // rubber-band mode, recover its instantaneous velocity and pass it as v0 to a critically
-    // damped spring. The spring then takes over — its natural motion handles the overshoot peak
-    // and the snap-back as one continuous solution, matching SpringTimingParameters' approach.
-    if (_rubberBandsAtRest) {
-        const CGFloat overshoot = _directionMultiplier * (targetOffset - _pageWidth);
-        if (overshoot > 0.0f) {
-            CGFloat absVelocity = 0.0f;
-            if (_activeEffectiveDuration > FLT_EPSILON) {
-                const CGFloat slopeDelta = (CGFloat)1e-3;
-                const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
-                const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
-                const CGFloat dxSpan = tA - tB;
-                if (dxSpan > FLT_EPSILON) {
-                    const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
-                    const CGFloat slope = dySpan / dxSpan;
-                    absVelocity = (_endOffset - _startOffset) * slope / (CGFloat)_activeEffectiveDuration;
-                }
-            }
-            const CGFloat signedVelocityIntoVoid = _directionMultiplier * absVelocity;
-            [self _startRubberBandSpringFromDisplacement:overshoot
-                                                velocity:signedVelocityIntoVoid
-                                                  atTime:displayLink.targetTimestamp];
-            // Apply this tick's spring value (which equals overshoot at t=0) so position is
-            // continuous through the hand-off; subsequent ticks fall into the spring branch.
-            const CGFloat absoluteOffset = TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * overshoot,
-                                                                             _environmentMetrics.displayScale);
-            scrollView.contentOffset = (CGPoint){absoluteOffset, 0.0f};
-            return;
-        }
+    // Hand off to the rubber-band spring the first tick the bezier crosses the rest boundary.
+    if (_rubberBandsAtRest && (_directionMultiplier * (targetOffset - _pageWidth)) > 0.0f) {
+        [self _handOffToRubberBandSpringAtLinearProgress:linearProgress targetOffset:targetOffset
+                                                  atTime:displayLink.targetTimestamp scrollView:scrollView];
+        return;
     }
 
     scrollView.contentOffset = (CGPoint){targetOffset, 0.0f};
-
-    // Natural-end for the regular bezier path. The rubber-band path can't reach here because
-    // it always exits via the spring hand-off above before the bezier completes.
     if (progress >= 1.0f - FLT_EPSILON && fabs(scrollView.contentOffset.x - _endOffset) <= _environmentMetrics.pixelSize) {
         [self stopAnimationWithCompletion:YES];
     }
 }
 
-- (void)_startRubberBandSpringFromDisplacement:(CGFloat)x0
-                                        velocity:(CGFloat)v0
-                                          atTime:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
-    // Critical damping: damping = 2·dampingRatio·sqrt(mass·stiffness), β = damping / (2·mass).
-    // For the closed-form solution x(t) = exp(-β·t)·(c1 + c2·t), c1 is the initial displacement
-    // and c2 is initialVelocity + β·displacement. v0 here is signed in the direction of motion,
-    // so positive means "still moving away from the rest position" — the spring then naturally
-    // continues past, peaks, and decays back toward 0.
-    const CGFloat damping = 2.0f * kTOAnimatorRubberBandSpringDampingRatio
-                                 * sqrt(kTOAnimatorRubberBandSpringMass * kTOAnimatorRubberBandSpringStiffness);
-    const CGFloat beta = damping / (2.0f * kTOAnimatorRubberBandSpringMass);
+#pragma mark - Rubber-band Spring -
 
+/// Evaluates the closed-form spring at `now` and writes the resulting offset, or settles to rest
+/// once the analytical duration has elapsed.
+- (void)_tickRubberBandSpringAtTime:(CFTimeInterval)now scrollView:(UIScrollView *)scrollView TOPAGINGVIEW_OBJC_DIRECT {
+    const CFTimeInterval t = now - _springStartTime;
+    if (t >= _springDuration) {
+        scrollView.contentOffset = (CGPoint){_pageWidth, 0.0f};
+        _isInSpringSettle = NO;
+        [self stopAnimationWithCompletion:YES];
+        return;
+    }
+    const CGFloat x = (CGFloat)(exp(-_springBeta * t) * (_springC1 + _springC2 * t));
+    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * x,
+                                                                          _environmentMetrics.displayScale), 0.0f};
+}
+
+/// Recovers the bezier's instantaneous velocity and arms the spring with that as v0, then writes
+/// the t=0 spring value (= overshoot) so the hand-off is continuous.
+- (void)_handOffToRubberBandSpringAtLinearProgress:(CGFloat)linearProgress
+                                       targetOffset:(CGFloat)targetOffset
+                                             atTime:(CFTimeInterval)now
+                                         scrollView:(UIScrollView *)scrollView TOPAGINGVIEW_OBJC_DIRECT {
+    const CGFloat overshoot = _directionMultiplier * (targetOffset - _pageWidth);
+    [self _armRubberBandSpringWithDisplacement:overshoot
+                                       velocity:_directionMultiplier * [self _bezierVelocityAtLinearProgress:linearProgress]
+                                         atTime:now];
+    scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(_pageWidth + _directionMultiplier * overshoot,
+                                                                          _environmentMetrics.displayScale), 0.0f};
+}
+
+/// Samples the bezier slope around `linearProgress` and converts to wall-clock pts/sec.
+- (CGFloat)_bezierVelocityAtLinearProgress:(CGFloat)linearProgress TOPAGINGVIEW_OBJC_DIRECT {
+    if (_activeEffectiveDuration <= FLT_EPSILON) { return 0.0f; }
+    const CGFloat slopeDelta = (CGFloat)1e-3;
+    const CGFloat tA = (CGFloat)fmin(1.0, linearProgress + slopeDelta);
+    const CGFloat tB = (CGFloat)fmax(0.0, linearProgress - slopeDelta);
+    const CGFloat dxSpan = tA - tB;
+    if (dxSpan <= FLT_EPSILON) { return 0.0f; }
+    const CGFloat dySpan = TOPagingViewAnimatorEvaluateEasing(tA) - TOPagingViewAnimatorEvaluateEasing(tB);
+    return (_endOffset - _startOffset) * (dySpan / dxSpan) / (CGFloat)_activeEffectiveDuration;
+}
+
+/// Sets up x(t) = exp(-β·t)·(c1 + c2·t) and computes its analytical settle duration. v0 is signed
+/// in the direction of motion; positive means "still moving away from rest".
+- (void)_armRubberBandSpringWithDisplacement:(CGFloat)x0 velocity:(CGFloat)v0 atTime:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
+    const CGFloat beta = sqrt(kTOAnimatorRubberBandSpringStiffness / kTOAnimatorRubberBandSpringMass)
+                       * kTOAnimatorRubberBandSpringDampingRatio;
     _springBeta = beta;
     _springC1 = x0;
     _springC2 = v0 + beta * x0;
     _springStartTime = now;
 
-    // Analytical settle duration (per ScrollMechanics' SpringTimingParameters): max of the times
-    // each component falls below the visible-motion threshold. If a component is already below
-    // the threshold (negative log argument) treat its contribution as zero.
+    // Settle time: max of when each closed-form component decays below `threshold`. Components
+    // already under the threshold contribute 0.
     const CGFloat threshold = kTOAnimatorRubberBandSpringSettleThreshold;
-    CFTimeInterval t1 = 0.0;
-    if (fabs(_springC1) > threshold * 0.5f) {
-        t1 = (1.0 / beta) * log(2.0 * fabs(_springC1) / threshold);
-    }
-    CFTimeInterval t2 = 0.0;
-    const CGFloat c2_lower_bound = (CGFloat)(M_E) * beta * threshold * 0.25f;
-    if (fabs(_springC2) > c2_lower_bound) {
-        t2 = (2.0 / beta) * log(4.0 * fabs(_springC2) / ((CGFloat)(M_E) * beta * threshold));
-    }
+    const CFTimeInterval t1 = (fabs(_springC1) > threshold * 0.5f)
+        ? (1.0 / beta) * log(2.0 * fabs(_springC1) / threshold) : 0.0;
+    const CFTimeInterval t2 = (fabs(_springC2) > (CGFloat)M_E * beta * threshold * 0.25f)
+        ? (2.0 / beta) * log(4.0 * fabs(_springC2) / ((CGFloat)M_E * beta * threshold)) : 0.0;
     _springDuration = fmax(0.0, fmax(t1, t2));
     _isInSpringSettle = YES;
 }

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -38,7 +38,7 @@ static const CFTimeInterval kTOAnimatorDefaultDuration = 0.5f;
 /// Critically damped rubber-band spring. Closed-form x(t) = exp(-β·t)·(c1 + c2·t)
 /// Higher stiffness = snappier; settleThreshold caps the duration once visible motion is sub-pixel.
 static const CGFloat kTOAnimatorRubberBandSpringMass            = 1.0f;
-static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 250.0f;
+static const CGFloat kTOAnimatorRubberBandSpringStiffness       = 500.0f;
 static const CGFloat kTOAnimatorRubberBandSpringSettleThreshold = 0.5f;
 
 /// Cubic bezier control points for the ease-out curve.

--- a/TOPagingView/Internal/TOPagingViewAnimator.m
+++ b/TOPagingView/Internal/TOPagingViewAnimator.m
@@ -277,12 +277,8 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
         // span * slopeAtStart / duration, with span = _pageWidth.
         const CGFloat dir = TOPagingViewAnimatorDirectionMultiplier(pageDirection);
         const CGFloat impulse = dir * _pageWidth * kTOAnimatorBezierInitialSlope / (CGFloat)segmentDuration;
-        _activeTiming = [TOPagingViewSpringTimingParameters timingParametersWithRestOffset:_pageWidth
-                                                                              displacement:(currentValue - _pageWidth)
-                                                                                  velocity:(currentVelocity + impulse)
-                                                                                      mass:kTOAnimatorRubberBandSpringMass
-                                                                                 stiffness:kTOAnimatorRubberBandSpringStiffness
-                                                                                 threshold:kTOAnimatorRubberBandSpringSettleThreshold];
+        _activeTiming = [self _rubberBandSpringFromDisplacement:(currentValue - _pageWidth)
+                                                        velocity:(currentVelocity + impulse)];
         _activeStartTime = referenceTime;
         return;
     }
@@ -407,9 +403,10 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
 
 /// If the active bezier has just carried the offset past the rest boundary, replace it with a
 /// spring whose v0 matches the bezier's instantaneous velocity. Returns YES if the swap fired.
-/// Assumes the rest position is `_pageWidth` (the middle slot), which is true for every site
-/// that arms `rubberBandsAtRest` today — the flag is only set when an adjacent-page fetch
-/// returns nil while the current page is centered.
+/// Assumes the rest position is `_pageWidth` (the middle slot). All callers that arm
+/// `rubberBandsAtRest` do so when the current page is centered — either implicitly when an
+/// adjacent-page fetch returns nil, or explicitly from the turn methods when the user taps
+/// past the last/first page.
 - (BOOL)_handOffBezierToSpringIfCrossingBoundaryAtValue:(CGFloat)value time:(CFTimeInterval)now TOPAGINGVIEW_OBJC_DIRECT {
     if (!_rubberBandsAtRest) { return NO; }
     if (![_activeTiming isKindOfClass:[TOPagingViewBezierTimingParameters class]]) { return NO; }
@@ -417,15 +414,23 @@ static inline CGFloat TOPagingViewAnimatorDirectionMultiplier(UIRectEdge directi
 
     TOPagingViewBezierTimingParameters *const bezier = (TOPagingViewBezierTimingParameters *)_activeTiming;
     const CGFloat velocity = [bezier velocityAtTime:(now - _activeStartTime)];
-    _activeTiming = [TOPagingViewSpringTimingParameters timingParametersWithRestOffset:_pageWidth
-                                                                          displacement:(value - _pageWidth)
-                                                                              velocity:velocity
-                                                                                  mass:kTOAnimatorRubberBandSpringMass
-                                                                             stiffness:kTOAnimatorRubberBandSpringStiffness
-                                                                             threshold:kTOAnimatorRubberBandSpringSettleThreshold];
+    _activeTiming = [self _rubberBandSpringFromDisplacement:(value - _pageWidth) velocity:velocity];
     _activeStartTime = now;
     _scrollView.contentOffset = (CGPoint){TOPagingViewAnimatorRoundToPixel(value, _environmentMetrics.displayScale), 0.0f};
     return YES;
+}
+
+/// Builds a critically-damped rubber-band spring around the middle slot. Centralizes the
+/// (mass, stiffness, threshold) constants so the impulse branch and the bezier-handoff path
+/// stay in sync.
+- (TOPagingViewSpringTimingParameters *)_rubberBandSpringFromDisplacement:(CGFloat)displacement
+                                                                  velocity:(CGFloat)velocity TOPAGINGVIEW_OBJC_DIRECT {
+    return [TOPagingViewSpringTimingParameters timingParametersWithRestOffset:_pageWidth
+                                                                  displacement:displacement
+                                                                      velocity:velocity
+                                                                          mass:kTOAnimatorRubberBandSpringMass
+                                                                     stiffness:kTOAnimatorRubberBandSpringStiffness
+                                                                     threshold:kTOAnimatorRubberBandSpringSettleThreshold];
 }
 
 #pragma mark - Environment -

--- a/TOPagingView/Internal/TOPagingViewConstants.h
+++ b/TOPagingView/Internal/TOPagingViewConstants.h
@@ -31,8 +31,8 @@ static NSString *const kTOPagingViewDefaultIdentifier = @"TOPagingView.DefaultPa
 static const CGFloat kTOPagingViewPageSlotCount = 3.0f;
 
 /// The amount of padding along the edge of the screen shown when the "no incoming page" animation plays.
-static const CGFloat kTOPagingViewBumperWidthCompact = 48.0f;
-static const CGFloat kTOPagingViewBumperWidthRegular = 96.0f;
+static const CGFloat kTOPagingViewBumperWidthCompact = 96.0f;
+static const CGFloat kTOPagingViewBumperWidthRegular = 192.0f;
 
 /// The animation options used for the bounce animation.
 static const UIViewAnimationOptions kTOPagingViewAnimationOptions = UIViewAnimationOptionAllowUserInteraction;

--- a/TOPagingView/Internal/TOPagingViewConstants.h
+++ b/TOPagingView/Internal/TOPagingViewConstants.h
@@ -31,8 +31,8 @@ static NSString *const kTOPagingViewDefaultIdentifier = @"TOPagingView.DefaultPa
 static const CGFloat kTOPagingViewPageSlotCount = 3.0f;
 
 /// The amount of padding along the edge of the screen shown when the "no incoming page" animation plays.
-static const CGFloat kTOPagingViewBumperWidthCompact = 96.0f;
-static const CGFloat kTOPagingViewBumperWidthRegular = 192.0f;
+static const CGFloat kTOPagingViewBumperWidthCompact = 128.0f;
+static const CGFloat kTOPagingViewBumperWidthRegular = 256.0f;
 
 /// The animation options used for the bounce animation.
 static const UIViewAnimationOptions kTOPagingViewAnimationOptions = UIViewAnimationOptionAllowUserInteraction;

--- a/TOPagingView/Internal/TOPagingViewConstants.h
+++ b/TOPagingView/Internal/TOPagingViewConstants.h
@@ -30,9 +30,5 @@ static NSString *const kTOPagingViewDefaultIdentifier = @"TOPagingView.DefaultPa
 /// There are always 3 slots, with content insetting used to block pages on either side.
 static const CGFloat kTOPagingViewPageSlotCount = 3.0f;
 
-/// The amount of padding along the edge of the screen shown when the "no incoming page" animation plays.
-static const CGFloat kTOPagingViewBumperWidthCompact = 128.0f;
-static const CGFloat kTOPagingViewBumperWidthRegular = 256.0f;
-
-/// The animation options used for the bounce animation.
+/// Animation options shared by the spring animations used during page rearrangement.
 static const UIViewAnimationOptions kTOPagingViewAnimationOptions = UIViewAnimationOptionAllowUserInteraction;

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -115,6 +115,12 @@
                                                    valueOptions:NSPointerFunctionsStrongMemory];
     _dragInteractionState = TOPagingViewDraggingStateReset();
 
+    // Seed the inset cache with a sentinel so the first call to TOPagingViewSetPageSlotEnabled
+    // is always a miss. Otherwise the zero-init would silently match a legitimate request to
+    // write 0 to an inset.
+    _cachedInsetLeft = CGFLOAT_MAX;
+    _cachedInsetRight = CGFLOAT_MAX;
+
     // Configure the main properties of this view
     self.clipsToBounds = YES;  // The scroll view intentionally overlaps, so this view MUST clip.
     self.backgroundColor = [UIColor clearColor];
@@ -379,6 +385,14 @@ static inline void TOPagingViewSetNextPageFrame(TOPagingView *view, CGRect frame
     view->_nextPageXPosition = frame.origin.x;
 }
 
+/// Assigns `_nextPageView` and clears the cached X position when the new value is nil so the
+/// cache can never be read pointing at a freed page. Non-nil assignments leave the cache to be
+/// refreshed by the upcoming `TOPagingViewSetNextPageFrame` call that positions the new page.
+static inline void TOPagingViewSetNextPageView(TOPagingView *view, UIView<TOPagingViewPage> *pageView) {
+    view->_nextPageView = pageView;
+    if (pageView == nil) { view->_nextPageXPosition = 0.0f; }
+}
+
 static inline void TOPagingViewSetPageDirectionForPageView(TOPagingView *view, TOPagingViewDirection direction, UIView<TOPagingViewPage> *pageView) {
     // Check the page view supports the page direction protocol and set it if it does
     if (pageView == nil) { return; }
@@ -423,7 +437,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     // Reset all of the active page references
     TOPagingViewSetCurrentPageView(self, nil);
     _previousPageView = nil;
-    _nextPageView = nil;
+    TOPagingViewSetNextPageView(self, nil);
     _isDragging = NO;
     _dragInteractionState = TOPagingViewDraggingStateReset();
 
@@ -444,7 +458,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (void)reloadAdjacentPages {
     // Reclaim the previous and next pages
-    TOPagingViewReclaimPageView(self, _nextPageView);     _nextPageView = nil;
+    TOPagingViewReclaimPageView(self, _nextPageView);     TOPagingViewSetNextPageView(self, nil);
     TOPagingViewReclaimPageView(self, _previousPageView); _previousPageView = nil;
 
     // Set the flags to yes to ensure the following flow isn't blocked
@@ -477,7 +491,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
         // Insert the new page into the scroll view and position it in the appropriate slot.
         TOPagingViewInsertPageView(self, pageView);
         if (isNext) {
-            _nextPageView = pageView;
+            TOPagingViewSetNextPageView(self, pageView);
             TOPagingViewSetNextPageFrame(self, _layoutMetrics.nextPageFrame);
         } else {
             _previousPageView = pageView;
@@ -651,8 +665,10 @@ static inline void TOPagingViewLayoutPages(TOPagingView *view) {
     };
 
     // When adaptive paging is enabled, we swap the on-screen 'next' page to either
-    // side of the initial page as the user swipes left and right
-    if (isDetectingDirection) {
+    // side of the initial page as the user swipes left and right. With no next page available
+    // (e.g. single-page data source, or last page reached) there's nothing to swap and the
+    // helper's `_nextPageView` invariant doesn't hold, so skip it.
+    if (isDetectingDirection && view->_hasNextPage) {
         TOPagingViewHandleAdaptivePageDirectionLayout(view, &metrics);
     }
 
@@ -768,13 +784,9 @@ static inline void TOPagingViewHandlePageTransitions(TOPagingView *view, TOPagin
     // Read animator state directly from the cached struct pointer — no ObjC msg sends per tick.
     const TOPagingViewAnimatorState *animatorState = view->_animatorState;
     const BOOL isAnimating = animatorState->isAnimating;
-    BOOL isAnimatingRight = NO;
-    BOOL isAnimatingLeft = NO;
-    if (isAnimating) {
-        const UIRectEdge direction = animatorState->direction;
-        isAnimatingRight = (direction == UIRectEdgeRight);
-        isAnimatingLeft = (direction == UIRectEdgeLeft);
-    }
+    const UIRectEdge animatorDirection = animatorState->direction;
+    const BOOL isAnimatingRight = isAnimating && animatorDirection == UIRectEdgeRight;
+    const BOOL isAnimatingLeft = isAnimating && animatorDirection == UIRectEdgeLeft;
 
     // By default, we only perform transitions when a new page has fully landed on screen.
     // This defers heavier layout work until there is no visible motion.
@@ -954,7 +966,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
 
     // Zero out the adjacent pages and set the
     // next/previous flags to ensure we'll query for new pages
-    _nextPageView = nil; _hasNextPage = NO;
+    TOPagingViewSetNextPageView(self, nil); _hasNextPage = NO;
     _previousPageView = nil; _hasPreviousPage = NO;
 
     // If we're not animating, we can rearrange everything statically and cancel out here
@@ -1114,7 +1126,7 @@ static inline void TOPagingViewTransitionOverToNextPage(TOPagingView *view) {
         // Update all of the references by pushing each view back
         view->_previousPageView = view->_currentPageView;
         TOPagingViewSetCurrentPageView(view, view->_nextPageView);
-        view->_nextPageView = nil;
+        TOPagingViewSetNextPageView(view, nil);
         NSCAssert(view->_currentPageView != nil, @"Current page view must not be nil after transitioning to next page.");
 
         // Update the frames of the pages
@@ -1160,7 +1172,7 @@ static inline void TOPagingViewTransitionOverToPreviousPage(TOPagingView *view) 
         TOPagingViewReclaimPageView(view, view->_nextPageView);
         
         // Update all of the references by pushing each view forward
-        view->_nextPageView = view->_currentPageView;
+        TOPagingViewSetNextPageView(view, view->_currentPageView);
         TOPagingViewSetCurrentPageView(view, view->_previousPageView);
         view->_previousPageView = nil;
         NSCAssert(view->_currentPageView != nil, @"Current page view must not be nil after transitioning to previous page.");

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1052,9 +1052,10 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
 - (void)_playBounceAnimationInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT {
     const BOOL isCompactSizeClass = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
     const CGFloat offsetModifier = (direction == UIRectEdgeLeft) ? -1.0f : 1.0f;
-    const CGFloat bumperPadding = (isCompactSizeClass ? kTOPagingViewBumperWidthCompact : kTOPagingViewBumperWidthRegular) * offsetModifier;
+    const CGFloat bumperPadding = ((isCompactSizeClass ? kTOPagingViewBumperWidthCompact : kTOPagingViewBumperWidthRegular) + _pageSpacing)
+                                    * offsetModifier;
     const CGPoint origin = (CGPoint){_layoutMetrics.pageWidth, 0.0f};
-    const CGPoint bumperOffset = (CGPoint){origin.x + bumperPadding, 0.0f};
+    const CGPoint bumperOffset = (CGPoint){origin.x + bumperPadding , 0.0f};
 
     // Set the various animation blocks so we pull to the side, and then snap back to the middle
     void (^pullAnimationBlock)(void) = ^{ [self->_scrollView setContentOffset:bumperOffset animated:NO]; };

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -498,8 +498,11 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
             _previousPageView.frame = _layoutMetrics.previousPageFrame;
         }
     } else if (clampAnimatorIfMissing) {
-        // If the adjacent page was nil while we were animating, cancel the animation.
-        [_pageAnimator clampAnimationToOffset:_layoutMetrics.pageWidth];
+        // No further page in this direction. Arm the animator to apply UIScrollView's rubber-band
+        // formula to any travel past the rest position — a legitimate landing on the new last
+        // page completes unchanged (no overshoot), and a stacked turn past it stretches with
+        // velocity-driven resistance instead of running off into the void.
+        _pageAnimator.rubberBandsAtRest = YES;
     }
 
     if (isNext) { _hasNextPage = (pageView != nil); }

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -498,9 +498,9 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
             _previousPageView.frame = _layoutMetrics.previousPageFrame;
         }
     } else if (rubberBandIfMissing) {
-        // No further page in this direction.
-        // Arm the animator to apply UIScrollView's rubber-band
-        // formula to any travel past the rest position.
+        // No further page in this direction. Arm the animator so any travel past the rest
+        // position hands off from the bezier to the critically-damped spring instead of
+        // sailing into the next slot.
         _pageAnimator.rubberBandsAtRest = YES;
     }
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -1064,10 +1064,10 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     // Completion block after the initial pull back is started
     void (^pullAnimationCompletionBlock)(BOOL) = ^(BOOL success) {
         // Play a very wobbly spring back animation snapping back into place
-        [UIView animateWithDuration:0.4f
+        [UIView animateWithDuration:0.65f
                               delay:0.0f
-             usingSpringWithDamping:0.3f
-              initialSpringVelocity:0.1f
+             usingSpringWithDamping:1.0f
+              initialSpringVelocity:1.0f
                             options:kTOPagingViewAnimationOptions
                          animations:popAnimationBlock
                          completion:popAnimationCompletionBlock];
@@ -1078,10 +1078,10 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
 
     // Kickstart the animation chain.
     // Play a very quick rubber-banding slide out to the bumper padding
-    [UIView animateWithDuration:0.1f
+    [UIView animateWithDuration:0.3f
                           delay:0.0f
          usingSpringWithDamping:1.0f
-          initialSpringVelocity:2.5f
+          initialSpringVelocity:0.0f
                         options:kTOPagingViewAnimationOptions
                      animations:pullAnimationBlock
                      completion:pullAnimationCompletionBlock];

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -593,10 +593,6 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 }
 
 - (void)turnToLeftPageAnimated:(BOOL)animated {
-    const CGFloat offset = _scrollView.contentOffset.x;
-    const CGFloat pageWidth = _layoutMetrics.pageWidth;
-    const BOOL isAnimating = _pageAnimator.isAnimating;
-    const BOOL isAnimatingLeft = isAnimating && _pageAnimator.direction == UIRectEdgeLeft;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(_pageScrollDirection);
     BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) || (!isDirectionReversed && _hasPreviousPage);
 
@@ -613,23 +609,19 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
         }
     }
 
-    // Play a bouncy animation if there's no page available on that side and
-    // the scroll view isn't already settling from a user-driven swipe.
-    if (!hasLeftPage && (offset <= pageWidth + FLT_EPSILON || isAnimatingLeft)) {
-        if (!animated || isAnimating) { return; }
-        [self _playBounceAnimationInDirection:UIRectEdgeLeft];
-        return;
+    // No page in this direction: arm the animator's rubber-band so the bezier→spring handoff
+    // bumps against the edge and snaps back. Each subsequent tap re-energises the spring,
+    // giving the user immediate feedback rather than a frozen wait. Without animation we
+    // have nowhere meaningful to land, so just no-op.
+    if (!hasLeftPage) {
+        if (!animated) { return; }
+        _pageAnimator.rubberBandsAtRest = YES;
     }
 
-    // Turn to the left side page
     [self _turnToPageInDirection:UIRectEdgeLeft animated:animated];
 }
 
 - (void)turnToRightPageAnimated:(BOOL)animated {
-    const CGFloat offset = _scrollView.contentOffset.x;
-    const CGFloat pageWidth = _layoutMetrics.pageWidth;
-    const BOOL isAnimating = _pageAnimator.isAnimating;
-    const BOOL isAnimatingRight = isAnimating && _pageAnimator.direction == UIRectEdgeRight;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(_pageScrollDirection);
     BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) || (!isDirectionReversed && _hasNextPage);
 
@@ -643,12 +635,10 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
         }
     }
 
-    // If we're partially at the last page and animating in, skip turning again to let it bottom out.
-    // Otherwise, we've hit the edge, so play a 'bounce' visual cue to make it clear there's no more pages.
-    if (!hasRightPage && (offset >= pageWidth - FLT_EPSILON || isAnimatingRight)) {
-        if (!animated || isAnimating) { return; }
-        [self _playBounceAnimationInDirection:UIRectEdgeRight];
-        return;
+    // See -turnToLeftPageAnimated: for the rationale on the rubber-band hand-off.
+    if (!hasRightPage) {
+        if (!animated) { return; }
+        _pageAnimator.rubberBandsAtRest = YES;
     }
 
     [self _turnToPageInDirection:UIRectEdgeRight animated:animated];
@@ -1047,45 +1037,6 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
                         options:kTOPagingViewAnimationOptions
                      animations:^{ [self->_scrollView setContentOffset:centerOffset animated:NO]; }
                      completion:completionBlock];
-}
-
-- (void)_playBounceAnimationInDirection:(UIRectEdge)direction TOPAGINGVIEW_OBJC_DIRECT {
-    const BOOL isCompactSizeClass = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
-    const CGFloat offsetModifier = (direction == UIRectEdgeLeft) ? -1.0f : 1.0f;
-    const CGFloat bumperPadding = ((isCompactSizeClass ? kTOPagingViewBumperWidthCompact : kTOPagingViewBumperWidthRegular) + _pageSpacing)
-                                    * offsetModifier;
-    const CGPoint origin = (CGPoint){_layoutMetrics.pageWidth, 0.0f};
-    const CGPoint bumperOffset = (CGPoint){origin.x + bumperPadding, 0.0f};
-
-    // Set the various animation blocks so we pull to the side, and then snap back to the middle
-    void (^pullAnimationBlock)(void) = ^{ [self->_scrollView setContentOffset:bumperOffset animated:NO]; };
-    void (^popAnimationBlock)(void) = ^{ [self->_scrollView setContentOffset:origin animated:NO]; };
-    void (^popAnimationCompletionBlock)(BOOL) = ^(BOOL success) { self->_disableLayout = NO; };
-
-    // Completion block after the initial pull back is started
-    void (^pullAnimationCompletionBlock)(BOOL) = ^(BOOL success) {
-        // Play a very wobbly spring back animation snapping back into place
-        [UIView animateWithDuration:0.65f
-                              delay:0.0f
-             usingSpringWithDamping:1.0f
-              initialSpringVelocity:1.0f
-                            options:kTOPagingViewAnimationOptions
-                         animations:popAnimationBlock
-                         completion:popAnimationCompletionBlock];
-    };
-
-    // Disable layout since the animation will manage everything
-    _disableLayout = YES;
-
-    // Kickstart the animation chain.
-    // Play a very quick rubber-banding slide out to the bumper padding
-    [UIView animateWithDuration:0.3f
-                          delay:0.0f
-         usingSpringWithDamping:1.0f
-          initialSpringVelocity:0.0f
-                        options:kTOPagingViewAnimationOptions
-                     animations:pullAnimationBlock
-                     completion:pullAnimationCompletionBlock];
 }
 
 #pragma mark - Page View Recycling

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -498,10 +498,9 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
             _previousPageView.frame = _layoutMetrics.previousPageFrame;
         }
     } else if (clampAnimatorIfMissing) {
-        // No further page in this direction. Arm the animator to apply UIScrollView's rubber-band
-        // formula to any travel past the rest position — a legitimate landing on the new last
-        // page completes unchanged (no overshoot), and a stacked turn past it stretches with
-        // velocity-driven resistance instead of running off into the void.
+        // No further page in this direction.
+        // Arm the animator to apply UIScrollView's rubber-band
+        // formula to any travel past the rest position.
         _pageAnimator.rubberBandsAtRest = YES;
     }
 

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -476,7 +476,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
 - (nullable UIView<TOPagingViewPage> *)_fetchAdjacentPageForType:(TOPagingViewPageType)pageType
                                                 currentPageView:(nullable UIView<TOPagingViewPage> *)currentPageView
-                                         clampAnimatorIfMissing:(BOOL)clampAnimatorIfMissing TOPAGINGVIEW_OBJC_DIRECT {
+                                         rubberBandIfMissing:(BOOL)rubberBandIfMissing TOPAGINGVIEW_OBJC_DIRECT {
     NSAssert(_dataSource != nil, @"Data source must be set before fetching pages.");
     NSAssert(pageType == TOPagingViewPageTypeNext || pageType == TOPagingViewPageTypePrevious,
              @"_fetchAdjacentPageForType: only handles Next or Previous page types.");
@@ -497,7 +497,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
             _previousPageView = pageView;
             _previousPageView.frame = _layoutMetrics.previousPageFrame;
         }
-    } else if (clampAnimatorIfMissing) {
+    } else if (rubberBandIfMissing) {
         // No further page in this direction.
         // Arm the animator to apply UIScrollView's rubber-band
         // formula to any travel past the rest position.
@@ -510,11 +510,11 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 }
 
 - (void)_fetchNewNextPage TOPAGINGVIEW_OBJC_DIRECT {
-    [self _fetchAdjacentPageForType:TOPagingViewPageTypeNext currentPageView:_currentPageView clampAnimatorIfMissing:YES];
+    [self _fetchAdjacentPageForType:TOPagingViewPageTypeNext currentPageView:_currentPageView rubberBandIfMissing:YES];
 }
 
 - (void)_fetchNewPreviousPage TOPAGINGVIEW_OBJC_DIRECT {
-    [self _fetchAdjacentPageForType:TOPagingViewPageTypePrevious currentPageView:_currentPageView clampAnimatorIfMissing:YES];
+    [self _fetchAdjacentPageForType:TOPagingViewPageTypePrevious currentPageView:_currentPageView rubberBandIfMissing:YES];
 }
 
 - (void)fetchAdjacentPagesIfAvailable {
@@ -522,12 +522,12 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
 
     // If there currently isn't a previous page, check again to see if there is one now.
     if (!_hasPreviousPage) {
-        [self _fetchAdjacentPageForType:TOPagingViewPageTypePrevious currentPageView:_currentPageView clampAnimatorIfMissing:NO];
+        [self _fetchAdjacentPageForType:TOPagingViewPageTypePrevious currentPageView:_currentPageView rubberBandIfMissing:NO];
     }
 
     // If there currently isn't a next page, check again
     if (!_hasNextPage) {
-        [self _fetchAdjacentPageForType:TOPagingViewPageTypeNext currentPageView:_currentPageView clampAnimatorIfMissing:NO];
+        [self _fetchAdjacentPageForType:TOPagingViewPageTypeNext currentPageView:_currentPageView rubberBandIfMissing:NO];
     }
 
     // If we're on the initial page, set the previous page state to match whatever the next state is
@@ -603,7 +603,7 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     // Re-poll the data source if the requested direction has no page slot. A user tap is the
     // freshest signal that they want to advance — if the data source has finished loading the
     // page since we last asked, pick it up here rather than wait for the async refresh path.
-    // If a clamp Hermite is mid-flight and the retry resolves the page, drop the settle so we
+    // If a rubber-band animation is mid-flight and the retry resolves the page, stop it so we
     // can redirect forward from the current visual position.
     if (!hasLeftPage) {
         [self fetchAdjacentPagesIfAvailable];
@@ -1055,7 +1055,7 @@ static inline void TOPagingViewSetPageSlotEnabled(TOPagingView *view, BOOL enabl
     const CGFloat bumperPadding = ((isCompactSizeClass ? kTOPagingViewBumperWidthCompact : kTOPagingViewBumperWidthRegular) + _pageSpacing)
                                     * offsetModifier;
     const CGPoint origin = (CGPoint){_layoutMetrics.pageWidth, 0.0f};
-    const CGPoint bumperOffset = (CGPoint){origin.x + bumperPadding , 0.0f};
+    const CGPoint bumperOffset = (CGPoint){origin.x + bumperPadding, 0.0f};
 
     // Set the various animation blocks so we pull to the side, and then snap back to the middle
     void (^pullAnimationBlock)(void) = ^{ [self->_scrollView setContentOffset:bumperOffset animated:NO]; };

--- a/TOPagingView/TOPagingView.m
+++ b/TOPagingView/TOPagingView.m
@@ -596,7 +596,20 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL isAnimating = _pageAnimator.isAnimating;
     const BOOL isAnimatingLeft = isAnimating && _pageAnimator.direction == UIRectEdgeLeft;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(_pageScrollDirection);
-    const BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) || (!isDirectionReversed && _hasPreviousPage);
+    BOOL hasLeftPage = (isDirectionReversed && _hasNextPage) || (!isDirectionReversed && _hasPreviousPage);
+
+    // Re-poll the data source if the requested direction has no page slot. A user tap is the
+    // freshest signal that they want to advance — if the data source has finished loading the
+    // page since we last asked, pick it up here rather than wait for the async refresh path.
+    // If a clamp Hermite is mid-flight and the retry resolves the page, drop the settle so we
+    // can redirect forward from the current visual position.
+    if (!hasLeftPage) {
+        [self fetchAdjacentPagesIfAvailable];
+        hasLeftPage = (isDirectionReversed && _hasNextPage) || (!isDirectionReversed && _hasPreviousPage);
+        if (hasLeftPage && _pageAnimator.isAnimating) {
+            [_pageAnimator stopAnimationWithCompletion:NO];
+        }
+    }
 
     // Play a bouncy animation if there's no page available on that side and
     // the scroll view isn't already settling from a user-driven swipe.
@@ -616,7 +629,17 @@ static inline TOPageViewProtocolFlags TOPagingViewCachedProtocolFlagsForPageView
     const BOOL isAnimating = _pageAnimator.isAnimating;
     const BOOL isAnimatingRight = isAnimating && _pageAnimator.direction == UIRectEdgeRight;
     const BOOL isDirectionReversed = TOPagingViewIsDirectionReversed(_pageScrollDirection);
-    const BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) || (!isDirectionReversed && _hasNextPage);
+    BOOL hasRightPage = (isDirectionReversed && _hasPreviousPage) || (!isDirectionReversed && _hasNextPage);
+
+    // Re-poll the data source if the requested direction has no page slot. See the matching
+    // block in -turnToLeftPageAnimated: for rationale.
+    if (!hasRightPage) {
+        [self fetchAdjacentPagesIfAvailable];
+        hasRightPage = (isDirectionReversed && _hasPreviousPage) || (!isDirectionReversed && _hasNextPage);
+        if (hasRightPage && _pageAnimator.isAnimating) {
+            [_pageAnimator stopAnimationWithCompletion:NO];
+        }
+    }
 
     // If we're partially at the last page and animating in, skip turning again to let it bottom out.
     // Otherwise, we've hit the edge, so play a 'bounce' visual cue to make it clear there's no more pages.

--- a/TOPagingViewExample/TOViewController.m
+++ b/TOPagingViewExample/TOViewController.m
@@ -46,7 +46,7 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
               currentPageView:(TOTestPageView *)currentPageView {
     TOTestPageView *pageView = [pagingView dequeueReusablePageView];
     if (self.pageIndex >= 5) { return nil; }
-    
+
     switch (type) {
     case TOPagingViewPageTypeCurrent:
         pageView.number = self.pageIndex;
@@ -176,7 +176,7 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
     tapRecognizer.delegate = self;
     [self.pagingView addGestureRecognizer:tapRecognizer];
     [self.pagingView.scrollView.panGestureRecognizer requireGestureRecognizerToFail:tapRecognizer];
-    
+
     // Add a button to toggle page turning direction
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.tintColor = [UIColor whiteColor];

--- a/TOPagingViewExample/TOViewController.m
+++ b/TOPagingViewExample/TOViewController.m
@@ -14,7 +14,7 @@
 static NSString *const kTOPagingViewAccessibilityIdentifier = @"paging_view";
 static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_button";
 
-@interface TOViewController () <TOPagingViewDataSource, TOPagingViewDelegate, UIScrollViewDelegate>
+@interface TOViewController () <TOPagingViewDataSource, TOPagingViewDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate>
 
 // Current page state tracking
 @property (nonatomic, assign) NSInteger pageIndex;
@@ -45,7 +45,8 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
                pageViewForType:(TOPagingViewPageType)type
               currentPageView:(TOTestPageView *)currentPageView {
     TOTestPageView *pageView = [pagingView dequeueReusablePageView];
-
+    if (self.pageIndex >= 5) { return nil; }
+    
     switch (type) {
     case TOPagingViewPageTypeCurrent:
         pageView.number = self.pageIndex;
@@ -119,6 +120,11 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
     }
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
+
 #pragma mark - UIScrollViewDelegate -
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
@@ -163,11 +169,14 @@ static NSString *const kTODirectionButtonAccessibilityIdentifier = @"direction_b
     // Force it to become first responder to receive keyboard input
     [self.pagingView becomeFirstResponder];
 
-    // Add a tap recognizer to turn pages
+    // Add a tap recognizer to turn pages. The delegate lets it recognize alongside the scroll
+    // view's pan, otherwise taps during deceleration get held up by gesture coordination.
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                     action:@selector(tapGestureRecognized:)];
+    tapRecognizer.delegate = self;
     [self.pagingView addGestureRecognizer:tapRecognizer];
-
+    [self.pagingView.scrollView.panGestureRecognizer requireGestureRecognizerToFail:tapRecognizer];
+    
     // Add a button to toggle page turning direction
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.tintColor = [UIColor whiteColor];


### PR DESCRIPTION
I still wasn't happy with the logic/animation that occurs when a user reached the final page in the sequence. Eating the final taps during the 'wall' animation felt incorrect from a UX perspective. Additionally, the previous 'bounce' animation was a bit too jarring.

Using Claude's help, this PR fixes both issues by implementing a spring animation that happens when the user hits the final page, regardless of current velocity. This spring animation is also used in place of the original pre-canned 'wall' animation, streamlining the codebase a little more nicely.